### PR TITLE
⚡ Bolt: Remove preload for 2.9MB non-LCP image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-26 - Preload Anti-pattern with Lazy Loading
+**Learning:** Preloading `images/about.jpg` (2.9MB) while also lazy-loading it via JS is contradictory. It forces a massive download that competes with the LCP candidate (`img_bg_2.jpg`), degrading initial load performance.
+**Action:** Remove preload tags for large, non-critical, or lazy-loaded assets. Ensure only LCP candidates and critical resources are preloaded.

--- a/index.html
+++ b/index.html
@@ -25,8 +25,6 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
-
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700&display=swap" rel="stylesheet">


### PR DESCRIPTION
💡 What: Removed `<link rel="preload" as="image" href="images/about.jpg">` from `index.html`.
🎯 Why: `images/about.jpg` is a massive 2.9MB file that is lazy-loaded by `js/main.js`. Preloading it forces an immediate download that competes with the actual LCP candidate (`images/img_bg_2.jpg`, 538KB), delaying the First Contentful Paint and Largest Contentful Paint.
📊 Impact: Frees up significant early bandwidth (~2.9MB) for critical assets (CSS, fonts, Hero image).
🔬 Measurement: Verified tag removal in `index.html` and ensured no regressions via `verify_changes.py`.

---
*PR created automatically by Jules for task [718893955683927776](https://jules.google.com/task/718893955683927776) started by @sofiadutta*