### PR TITLE
🎨 Palette: Add copy-to-clipboard button for contact email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										sofia DOT dutta 17 AT gmail DOT com
+										<button id="btn-copy-email" class="btn btn-sm btn-primary" aria-label="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,28 @@
 		}
 	};
 
+	var setupCopyEmail = function() {
+		var $btn = $('#btn-copy-email');
+		var originalContent = $btn.html();
+
+		$btn.on('click', function(event) {
+			event.preventDefault();
+			var email = "sofia.dutta17@gmail.com";
+
+			var $temp = $("<input>");
+			$("body").append($temp);
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			$btn.html('<i class="icon-tick" aria-hidden="true"></i> Copied!');
+
+			setTimeout(function() {
+				$btn.html(originalContent);
+			}, 2000);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +361,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		setupCopyEmail();
 	});
 
 


### PR DESCRIPTION
This PR introduces a micro-UX improvement in the Contact section.

**Changes:**
1.  **HTML (`index.html`):** Added a "Copy" button next to the email address. The button uses existing Bootstrap classes (`btn`, `btn-sm`, `btn-primary`) and Icomoon icons (`icon-clipboard3`).
2.  **JavaScript (`js/main.js`):** Added a `setupCopyEmail` function that:
    *   Listens for clicks on the new button.
    *   Copies the email address `sofia.dutta17@gmail.com` to the clipboard.
    *   Uses a temporary input element and `document.execCommand('copy')` to ensure compatibility with older browsers and non-secure contexts (common in static portfolio templates).
    *   Updates the button text and icon to indicate success ("Copied!").
    *   Reverts the button state after 2 seconds.

**Verification:**
*   Created and ran a Playwright script `verify_email_copy.py`.
*   Verified the button appears correctly.
*   Verified clicking the button triggers the text change to "Copied!" and updates the icon.
*   The implementation stays within the <50 lines limit and reuses existing styles.

**Accessibility:**
*   The button has an `aria-label="Copy email address"`.
*   Icons are decorative (`aria-hidden="true"`).


---
*PR created automatically by Jules for task [3078107219535345469](https://jules.google.com/task/3078107219535345469) started by @sofiadutta*