### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attribute to YouTube iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
Added the `sandbox` attribute to YouTube video iframes in `index.html` to restrict their capabilities, implementing a defense-in-depth security enhancement.

The sandbox flags used are:
- `allow-scripts`: Required for the video player to function.
- `allow-same-origin`: Required for YouTube's internal API requests.
- `allow-presentation`: Required for full-screen and casting.
- `allow-popups`: Required for some interactive features (though minimal).

This prevents the iframe from performing actions like top-level navigation or executing plugins, reducing the attack surface.

---
*PR created automatically by Jules for task [5996481456174834044](https://jules.google.com/task/5996481456174834044) started by @sofiadutta*