### PR TITLE
⚡ Bolt: Conditionally preload sidebar image

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar profile image only on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 **What:** Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.

🎯 **Why:** The `images/about.jpg` file is a 2.9MB asset located in the sidebar. On mobile devices (viewport <= 768px), the sidebar is hidden by default. Unconditionally preloading this large image wastes significant bandwidth on mobile connections and contends with critical resources needed for the initial render.

📊 **Impact:** Prevents the download of 2.9MB on mobile devices during initial page load.

🔬 **Measurement:** Verified using Playwright (simulating desktop and mobile viewports) to confirm the sidebar visibility logic matches the media query. Validated that the image is still preloaded on desktop. Baseline regression tests passed.

---
*PR created automatically by Jules for task [8943141245182974324](https://jules.google.com/task/8943141245182974324) started by @sofiadutta*