### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>sofia DOT dutta 17 AT gmail DOT com <button id="btn-copy-email" class="btn btn-xs btn-default" aria-label="Copy email address" title="Copy email address" style="margin-left: 10px;"><i class="icon-clipboard3" aria-hidden="true"></i></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,35 @@
 		}
 	};
 
+	var copyEmailToClipboard = function() {
+		$('#btn-copy-email').click(function(event) {
+			event.preventDefault();
+			var email = "sofia.dutta17@gmail.com";
+
+			// Create temp element
+			var $temp = $("<input>");
+			$("body").append($temp);
+			// Position absolute to prevent page jump
+			$temp.css({position: 'absolute', left: '-9999px'});
+			$temp.val(email).select();
+
+			try {
+				document.execCommand("copy");
+				// Visual feedback
+				var $icon = $(this).find('i');
+				$icon.removeClass('icon-clipboard3').addClass('icon-tick');
+
+				setTimeout(function() {
+					$icon.removeClass('icon-tick').addClass('icon-clipboard3');
+				}, 2000);
+			} catch (err) {
+				console.error('Failed to copy email', err);
+			}
+
+			$temp.remove();
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +368,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a "Copy Email" button next to the obfuscated email address in the Contact section.
🎯 Why: Makes it easier for users to get the contact email without manual de-obfuscation, while preserving the anti-spam format in the DOM.
📸 Before/After: Added a small button with clipboard icon that turns to a checkmark on click.
♿ Accessibility: Button includes `aria-label` and `title`. Visual feedback provided via icon change.

---
*PR created automatically by Jules for task [3313222231545277228](https://jules.google.com/task/3313222231545277228) started by @sofiadutta*