### PR TITLE
⚡ Bolt: Optimize sidebar image preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload only on desktop to prevent wasting bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `preload` tag for `images/about.jpg`.
🎯 Why: `images/about.jpg` is a 2.9MB asset used only in the sidebar. On mobile devices (viewport < 769px), the sidebar is hidden initially. Unconditional preloading wastes significant bandwidth and delays LCP on mobile.
📊 Impact: Saves ~2.9MB of data transfer on initial load for mobile users.
🔬 Measurement: Verify `index.html` contains the `media` attribute on the preload link.

---
*PR created automatically by Jules for task [11525504429566507015](https://jules.google.com/task/11525504429566507015) started by @sofiadutta*