### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email address

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="email-text">sofia DOT dutta 17 AT gmail DOT com</span> <button class="btn btn-sm btn-primary js-copy-email" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard3" aria-hidden="true"></i> <span class="btn-text">Copy</span></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,48 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').on('click', function(event) {
+			event.preventDefault();
+			var $btn = $(this);
+			var $icon = $btn.find('i');
+			var $text = $btn.find('.btn-text');
+
+			// Reconstruct email
+			var rawText = $('#email-text').text();
+			var email = rawText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s+/g, '');
+
+			// Copy logic
+			var $temp = $("<input>");
+			$("body").append($temp);
+			$temp.css({position: 'absolute', left: '-9999px', top: '0'});
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			// Visual feedback
+			var originalIcon = "icon-clipboard3";
+			var successIcon = "icon-tick";
+
+			$icon.removeClass(originalIcon).addClass(successIcon);
+			$text.text("Copied!");
+			$btn.attr('aria-label', 'Email copied');
+
+			// Reset after 2 seconds
+			if ($btn.data('timeout')) {
+				clearTimeout($btn.data('timeout'));
+			}
+
+			var timeout = setTimeout(function() {
+				$icon.removeClass(successIcon).addClass(originalIcon);
+				$text.text("Copy");
+				$btn.attr('aria-label', 'Copy email address');
+			}, 2000);
+
+			$btn.data('timeout', timeout);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +381,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
This PR adds a copy-to-clipboard button for the contact email address.

**Why:**
The email address is currently obfuscated (e.g., `sofia DOT dutta...`) to prevent spam. This makes it difficult for users to contact the person as they have to manually type or fix the address.

**What:**
- Added a "Copy" button next to the email.
- When clicked, it reconstructs the valid email address and copies it to the clipboard.
- Provides immediate visual feedback ("Copied!" text and checkmark icon).

**Verification:**
- Verified using Playwright script (screenshots checked).
- Visual feedback loop works as expected.
- Email reconstruction logic verified.

---
*PR created automatically by Jules for task [2151895033059326514](https://jules.google.com/task/2151895033059326514) started by @sofiadutta*