### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix email exposure and mailto target blank

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-02-20 - Email Obfuscation Implementation
+**Vulnerability:** Exposed `mailto:` links allowed email harvesting by bots, and `target="_blank"` on these links caused poor UX (blank tabs).
+**Learning:** Static sites require client-side strategies for PII protection. A data-attribute pattern effectively decouples the email from the static HTML source.
+**Prevention:** Use `.email-obfuscated` class with `data-user` and `data-domain` attributes. Avoid `target="_blank"` on `mailto` links.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" class="btn-hire email-obfuscated" data-user="sofia.dutta17" data-domain="gmail.com" rel="noopener noreferrer">Hire me</a>
 									</div>
 								</div>
 							</div>
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><a href="#" class="email-obfuscated" data-user="sofia.dutta17" data-domain="gmail.com">sofia DOT dutta 17 AT gmail DOT com</a></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,15 @@
 		}
 	};
 
+	var emailObfuscation = function() {
+		$(document).on('click', '.email-obfuscated', function(e) {
+			e.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			window.location.href = 'mailto:' + user + '@' + domain;
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +348,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailObfuscation();
 	});
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hardcoded `mailto:` links exposed the email address to harvesters. Additionally, `target="_blank"` on mailto links caused unnecessary blank tabs and potential security risks (though mitigated by `noopener`).
🎯 Impact: Increased spam and poor user experience.
🔧 Fix: Replaced hardcoded links with `data-user` and `data-domain` attributes. Added a JavaScript handler to reconstruct the link on click.
✅ Verification: Verified using `verify_email_security.py` (deleted after use) that the email is no longer in the source and the click handler works. Verified no regressions with `verify_changes.py`.

---
*PR created automatically by Jules for task [8924384635801297634](https://jules.google.com/task/8924384635801297634) started by @sofiadutta*