### PR TITLE
⚡ Bolt: Conditional preload for large sidebar image

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop to save 2.9MB on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.

🎯 Why: To prevent mobile devices (where the sidebar containing this image is hidden by default) from downloading a 2.9MB asset during initial load.

📊 Impact: Reduces initial page load data size by approximately 2.9MB for users on devices with viewport width <= 768px.

🔬 Measurement: Verified the presence of the `media` attribute in `index.html`. Visual verification via Playwright confirmed no regressions in layout or rendering.

---
*PR created automatically by Jules for task [14514175577013489358](https://jules.google.com/task/14514175577013489358) started by @sofiadutta*