### PR TITLE
⚡ Bolt: Optimize large asset preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload about.jpg only on desktop where sidebar is visible to save bandwidth on mobile (2.9MB) -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 **What:** Added a `media="(min-width: 769px)"` attribute to the `<link rel="preload">` tag for `images/about.jpg`.

🎯 **Why:** The profile image `images/about.jpg` is 2.9MB and located in the sidebar. On mobile devices (viewport <= 768px), the sidebar is hidden (off-canvas) by default. Without the `media` attribute, browsers force-download this large asset immediately, competing with critical resources (CSS, JS, hero image) and delaying First Contentful Paint (FCP) and Largest Contentful Paint (LCP) on mobile networks.

📊 **Impact:** 
- **Mobile:** Saves **~2.9MB** of data transfer on initial load.
- **Desktop:** No change; image is still preloaded for immediate display.

🔬 **Measurement:**
- Verified via `verify_preload.py` that the `media` attribute is correctly applied.
- Visually confirmed that the sidebar and image logic in `js/main.js` (lazy loading background) is compatible with this change (the image will load when the sidebar is opened or if the viewport is large enough).

---
*PR created automatically by Jules for task [13485751624423489562](https://jules.google.com/task/13485751624423489562) started by @sofiadutta*