### PR TITLE
⚡ Bolt: Optimize preload for large sidebar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-08 - Conditional Preloading for Responsive Assets
+**Learning:** Large assets that are hidden on mobile via CSS (e.g., sidebar images) should not be unconditionally preloaded. This competes with critical mobile resources.
+**Action:** Use the `media` attribute in `<link rel="preload">` tags (e.g., `media="(min-width: 769px)"`) to restrict preloading to devices where the asset is actually visible.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the preload tag for `images/about.jpg`.
🎯 Why: The 2.9MB sidebar image is hidden on mobile devices (<769px). Preloading it unconditionally was wasting bandwidth and potentially delaying LCP for mobile users.
📊 Impact: Prevents downloading 2.9MB of non-critical data on mobile initial load.
🔬 Measurement: Verified that the preload tag now includes the correct media attribute.

---
*PR created automatically by Jules for task [5804706294654570488](https://jules.google.com/task/5804706294654570488) started by @sofiadutta*