### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email address

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p class="email-container" style="display: flex; align-items: center;">
+										<span class="email-text" data-user="sofia.dutta17" data-domain="gmail.com">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-primary btn-sm js-copy-email" aria-label="Copy email address" title="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3" aria-hidden="true"></i> <span class="btn-text">Copy</span>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,47 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').click(function(e) {
+			e.preventDefault();
+			var $this = $(this);
+			var $text = $this.find('.btn-text');
+			var $icon = $this.find('i');
+			var originalText = 'Copy';
+			var originalIcon = 'icon-clipboard3';
+			var successText = 'Copied!';
+			var successIcon = 'icon-tick';
+
+			var user = $this.siblings('.email-text').data('user');
+			var domain = $this.siblings('.email-text').data('domain');
+			var email = user + '@' + domain;
+
+			// Copy logic
+			var $temp = $("<input>");
+			$("body").append($temp);
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			// UI Feedback
+			$text.text(successText);
+			$icon.removeClass(originalIcon).addClass(successIcon);
+
+			// Clear existing timeout
+			if ($this.data('timeout')) {
+				clearTimeout($this.data('timeout'));
+			}
+
+			// Set new timeout
+			var timeoutId = setTimeout(function() {
+				$text.text(originalText);
+				$icon.removeClass(successIcon).addClass(originalIcon);
+			}, 2000);
+
+			$this.data('timeout', timeoutId);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +380,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
Implemented a micro-UX improvement by adding a 'Copy' button to the contact email. 
- Modified `index.html` to structure the email address with a span and button.
- Updated `js/main.js` to handle the copy logic using `document.execCommand('copy')` (for compatibility) and provide visual feedback ("Copied!").
- Ensured accessibility with ARIA labels and flexbox alignment.
- Verified visually using Playwright.

---
*PR created automatically by Jules for task [10410463394567649098](https://jules.google.com/task/10410463394567649098) started by @sofiadutta*