### PR TITLE
⚡ Bolt: Optimize about.jpg preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: `images/about.jpg` is a 2.9MB asset located in the sidebar, which is hidden on mobile devices. Preloading it on mobile wastes bandwidth and delays other critical resources.
📊 Impact: Saves ~2.9MB of data on initial load for mobile users.
🔬 Measurement: Verified via `index.html` inspection. Checked `verify_changes.py` to ensure no regressions (ignoring known copyright text issue).

---
*PR created automatically by Jules for task [58856571369717187](https://jules.google.com/task/58856571369717187) started by @sofiadutta*