### PR TITLE
🎨 Palette: Add Copy-to-Clipboard Button for Email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span class="email-text" data-user="sofia.dutta17" data-domain="gmail.com">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-sm btn-primary btn-outline js-copy-email" aria-label="Copy email address to clipboard" title="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,58 @@
 		}
 	};
 
+	var setupEmailCopy = function() {
+		$('.js-copy-email').on('click', function(event) {
+			event.preventDefault();
+			var $btn = $(this);
+			var $emailContainer = $btn.prev('.email-text');
+
+			// Construct email from attributes
+			var user = $emailContainer.data('user');
+			var domain = $emailContainer.data('domain');
+			var email = user + '@' + domain;
+
+			if (!user || !domain) {
+				// Fallback if data attributes are missing
+				email = "sofia.dutta17@gmail.com";
+			}
+
+			// Copy to clipboard logic
+			var $temp = $("<input>");
+			$("body").append($temp);
+			$temp.val(email).select();
+
+			try {
+				document.execCommand("copy");
+
+				// Clear any existing timeout
+				var existingTimeout = $btn.data('timeout');
+				if (existingTimeout) {
+					clearTimeout(existingTimeout);
+				}
+
+				// Feedback
+				var originalHtml = '<i class="icon-clipboard3" aria-hidden="true"></i> Copy';
+				$btn.html('<i class="icon-tick" aria-hidden="true"></i> Copied!');
+				$btn.removeClass('btn-primary btn-outline').addClass('btn-success');
+
+				var timeoutId = setTimeout(function() {
+					$btn.html(originalHtml);
+					$btn.removeClass('btn-success').addClass('btn-primary btn-outline');
+					$btn.data('timeout', null);
+				}, 2000);
+
+				$btn.data('timeout', timeoutId);
+
+			} catch (err) {
+				console.error('Failed to copy', err);
+				$btn.text('Error');
+			}
+
+			$temp.remove();
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +391,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		setupEmailCopy();
 	});
 
 


### PR DESCRIPTION
Added a "Copy" button to the contact section to allow users to easily copy the email address `sofia.dutta17@gmail.com` to their clipboard, replacing the need to manually transcribe the obfuscated text. The implementation uses existing Bootstrap classes and the Icomoon font library, ensuring consistent styling and accessibility.

---
*PR created automatically by Jules for task [871745124571081299](https://jules.google.com/task/871745124571081299) started by @sofiadutta*