### PR TITLE
🛡️ Sentinel: Obfuscate email addresses to prevent scraping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-05-20 - Email Obfuscation and Clipboard API
+**Vulnerability:** Raw `mailto:` links expose email addresses to automated scrapers.
+**Learning:** `navigator.clipboard` requires a secure context (HTTPS/localhost). In environments like local file access (`file://`) or older browsers, `document.execCommand('copy')` is a necessary fallback. Also, Playwright's text assertions respect CSS `text-transform`, requiring case-insensitive checks.
+**Prevention:** Use a dual-strategy (Clipboard API + fallback) for copy features and replace static `mailto:` links with dynamic, user-initiated actions.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" class="btn-hire js-copy-email" data-user="sofia.dutta17" data-domain="gmail.com" title="Copy email address">Hire me <i class="icon-clipboard3"></i></a>
 									</div>
 								</div>
 							</div>
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span class="email-text">sofia.dutta17 [at] gmail [dot] com</span>
+										<a href="#" class="js-copy-email" data-user="sofia.dutta17" data-domain="gmail.com" title="Copy email address" style="margin-left: 10px;"><i class="icon-clipboard3"></i></a>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,78 @@
 		}
 	};
 
+	var initEmailProtection = function() {
+		$('.js-copy-email').on('click', function(e) {
+			e.preventDefault();
+			var $this = $(this);
+			var user = $this.data('user');
+			var domain = $this.data('domain');
+			var email = user + '@' + domain;
+
+			// Clipboard API with fallback
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(email).then(function() {
+					showFeedback($this);
+				}, function(err) {
+					fallbackCopyTextToClipboard(email, $this);
+				});
+			} else {
+				fallbackCopyTextToClipboard(email, $this);
+			}
+		});
+	};
+
+	var fallbackCopyTextToClipboard = function(text, $btn) {
+		var textArea = document.createElement("textarea");
+		textArea.value = text;
+
+		// Ensure it's not visible but part of DOM
+		textArea.style.position = "fixed";
+		textArea.style.left = "-9999px";
+		textArea.style.top = "0";
+
+		document.body.appendChild(textArea);
+		textArea.focus();
+		textArea.select();
+
+		try {
+			var successful = document.execCommand('copy');
+			if (successful) {
+				showFeedback($btn);
+			}
+		} catch (err) {
+			console.error('Fallback: Oops, unable to copy', err);
+		}
+
+		document.body.removeChild(textArea);
+	};
+
+	var showFeedback = function($btn) {
+		var originalHtml = $btn.html();
+		// Check if we are already showing feedback to avoid race conditions
+		if ($btn.data('timeout')) {
+			clearTimeout($btn.data('timeout'));
+			$btn.html($btn.data('original-html')); // Restore immediately to start fresh
+		} else {
+			$btn.data('original-html', originalHtml);
+		}
+
+		// Change icon to checkmark and text
+		if ($btn.hasClass('btn-hire')) {
+			$btn.html('Copied! <i class="icon-tick"></i>');
+		} else {
+			$btn.html('<i class="icon-tick"></i>');
+		}
+
+		var timeoutId = setTimeout(function() {
+			$btn.html($btn.data('original-html'));
+			$btn.removeData('timeout');
+			$btn.removeData('original-html');
+		}, 2000);
+
+		$btn.data('timeout', timeoutId);
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +411,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initEmailProtection();
 	});
 
 


### PR DESCRIPTION
Obfuscate email addresses to prevent scraping by replacing mailto links with dynamic copy-to-clipboard buttons.

---
*PR created automatically by Jules for task [5667860973127471018](https://jules.google.com/task/5667860973127471018) started by @sofiadutta*