### PR TITLE
⚡ Bolt: Conditional preload for sidebar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-14 - Conditional Preloading for Responsive Assets
+**Learning:** `images/about.jpg` (2.9MB) was being preloaded unconditionally, even on mobile devices where the sidebar is hidden (off-canvas). This wasted significant bandwidth.
+**Action:** Used `media="(min-width: 769px)"` on the `<link rel="preload">` tag to restrict preloading to desktop viewports where the asset is actually visible. This is a highly effective, low-risk optimization for large, responsive assets.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop (when visible) to save 2.9MB on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 **What:** Added `media="(min-width: 769px)"` to the `<link rel="preload" href="images/about.jpg">` tag in `index.html`.

🎯 **Why:** The sidebar image (`images/about.jpg`) is 2.9MB. On mobile devices (viewport <= 768px), the sidebar is hidden off-screen by default. Preloading this large asset unconditionally wastes bandwidth and delays other critical resources on mobile networks.

📊 **Impact:** Saves ~2.9MB of data transfer for mobile users during the initial page load.

🔬 **Measurement:** Verified via `grep` that the media attribute is correctly applied to the preload tag in `index.html`. A temporary python script confirmed the presence and correctness of the tag.

---
*PR created automatically by Jules for task [6569059508320252520](https://jules.google.com/task/6569059508320252520) started by @sofiadutta*