### PR TITLE
🎨 Palette: Add Copy-to-Clipboard for Email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span class="email-text" data-user="sofia.dutta17" data-domain="gmail.com">sofia.dutta17 [at] gmail.com</span>
+										<button class="btn btn-primary btn-sm js-copy-email" aria-label="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3"></i> <span class="btn-text">Copy</span>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,76 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').click(function(e) {
+			e.preventDefault();
+			var $this = $(this);
+			var $emailSpan = $this.siblings('.email-text');
+			var email = $emailSpan.data('user') + '@' + $emailSpan.data('domain');
+
+			var fallbackCopy = function(text) {
+				var textArea = document.createElement("textarea");
+				textArea.value = text;
+				textArea.style.position = "fixed";
+				textArea.style.left = "-9999px";
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+				try {
+					var successful = document.execCommand('copy');
+					document.body.removeChild(textArea);
+					if (successful) {
+						return Promise.resolve();
+					} else {
+						return Promise.reject(new Error("execCommand returned false"));
+					}
+				} catch (err) {
+					document.body.removeChild(textArea);
+					return Promise.reject(err);
+				}
+			};
+
+			var copyToClipboard = function(text) {
+				if (navigator.clipboard && window.isSecureContext) {
+					return navigator.clipboard.writeText(text).catch(function(err) {
+						console.log("Clipboard API failed, trying fallback", err);
+						return fallbackCopy(text);
+					});
+				} else {
+					return fallbackCopy(text);
+				}
+			};
+
+			copyToClipboard(email).then(function() {
+				var $icon = $this.find('i');
+				var $text = $this.find('.btn-text');
+
+				// Store original state if not stored
+				if (!$this.data('original-text')) {
+					$this.data('original-text', $text.text());
+					$this.data('original-icon', $icon.attr('class'));
+				}
+
+				// Clear existing timeout
+				if ($this.data('timeout')) {
+					clearTimeout($this.data('timeout'));
+				}
+
+				$icon.removeClass().addClass('icon-tick');
+				$text.text('Copied!');
+
+				var timeoutId = setTimeout(function() {
+					$icon.removeClass().addClass($this.data('original-icon'));
+					$text.text($this.data('original-text'));
+				}, 2000);
+
+				$this.data('timeout', timeoutId);
+			}).catch(function(err) {
+				console.error("Failed to copy email", err);
+			});
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +409,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
**What:**
- Replaced the static, obfuscated email text in the Contact section with a "Copy" button.
- Implemented robust JavaScript logic to copy the email address `sofia.dutta17@gmail.com` to the clipboard.
- Added a fallback mechanism using `document.execCommand('copy')` for environments where the Clipboard API is restricted (e.g., non-secure contexts).

**Why:**
- Improves UX by allowing users to easily copy the email address without manual selection or typing.
- Maintains some level of source obfuscation (via data attributes) while making the UI more usable.

**Accessibility:**
- Added `aria-label="Copy email address"` to the copy button.
- Button is keyboard focusable.
- Visual feedback ("Copied!" and checkmark icon) is provided for 2 seconds.

**Verification:**
- Verified using a Playwright script that tested the click interaction, fallback mechanism (due to environment constraints), and visual feedback (text change to "Copied!").
- Confirmed the button reverts to its original state after the timeout.

---
*PR created automatically by Jules for task [12721289606449350235](https://jules.google.com/task/12721289606449350235) started by @sofiadutta*