### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix email exposure and mailto UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" class="btn-hire js-email-protect" data-user="sofia.dutta17" data-domain="gmail.com">Hire me</a>
 									</div>
 								</div>
 							</div>

--- a/js/main.js
+++ b/js/main.js
@@ -290,6 +290,16 @@
 
 	};
 
+	var secureEmail = function() {
+		$('.js-email-protect').on('click', function(e) {
+			e.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			var email = user + '@' + domain;
+			window.location.href = 'mailto:' + email;
+		});
+	};
+
 	var lazyLoadBackgrounds = function() {
 		var lazyBackgrounds = [].slice.call(document.querySelectorAll("[data-bg]"));
 
@@ -339,6 +349,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		secureEmail();
 	});
 
 

--- a/verification/verify_email_fix.py
+++ b/verification/verify_email_fix.py
@@ -1,0 +1,46 @@
+import os
+import time
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def test_email_obfuscation(page):
+    # Navigate to the page
+    page.goto("http://localhost:8080/index.html")
+
+    # Locate the Hire me button
+    # It has text "Hire me" and class "btn-hire"
+    hire_btn = page.locator(".btn-hire")
+
+    # Check it is visible
+    expect(hire_btn).to_be_visible()
+
+    # Check attributes
+    expect(hire_btn).to_have_attribute("href", "#")
+    expect(hire_btn).to_have_attribute("data-user", "sofia.dutta17")
+    expect(hire_btn).to_have_attribute("data-domain", "gmail.com")
+    expect(hire_btn).to_have_class(re.compile(r"js-email-protect"))
+
+    # Verify NO target="_blank"
+    target = hire_btn.get_attribute("target")
+    assert target != "_blank", f"Expected target != '_blank', got {target}"
+
+    # Scroll to it for screenshot
+    hire_btn.scroll_into_view_if_needed()
+    # Force wait a bit for animations
+    page.wait_for_timeout(1000)
+
+    # Take screenshot
+    os.makedirs("/home/jules/verification", exist_ok=True)
+    page.screenshot(path="/home/jules/verification/email_fix.png")
+    print("Screenshot saved to /home/jules/verification/email_fix.png")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # Use desktop viewport
+        context = browser.new_context(viewport={"width": 1280, "height": 1024})
+        page = context.new_page()
+        try:
+            test_email_obfuscation(page)
+        finally:
+            browser.close()


### PR DESCRIPTION
Obfuscated the email address in the "Hire me" button to prevent scraping and removed the `target="_blank"` attribute from the mailto link to improve user experience. Implemented a `secureEmail` function in `js/main.js` to handle the email link click dynamically. Verified the changes with a Playwright script.

---
*PR created automatically by Jules for task [4103143193263239414](https://jules.google.com/task/4103143193263239414) started by @sofiadutta*