### PR TITLE
⚡ Bolt: Conditional preload for sidebar image to save bandwidth on mobile

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-08 - Conditional Preload for Hidden Content
+**Learning:** For large assets in off-canvas or hidden menus (e.g., mobile sidebars), unconditional `<link rel="preload">` wastes bandwidth. Using the `media` attribute (e.g., `media="(min-width: 769px)"`) allows limiting the preload to devices where the content is initially visible.
+**Action:** When preloading assets, always consider if the asset is critical for *all* viewports. If not, use `media` queries to scope the preload.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar profile photo only on desktop to save 2.9MB on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Restricted the preload of `images/about.jpg` to viewports wider than 768px.
🎯 Why: To prevent downloading a large (2.9MB) image on mobile devices where it is initially hidden in the off-canvas sidebar.
📊 Impact: Reduces initial mobile page weight by ~2.9MB.
🔬 Measurement: Verified using a Playwright script (`verify_preload.py` - deleted before commit) that intercepts network requests. Confirmed that the image is not requested on mobile load, but is requested on desktop load and when the mobile menu is opened.

---
*PR created automatically by Jules for task [12967368558485766249](https://jules.google.com/task/12967368558485766249) started by @sofiadutta*