### PR TITLE
🎨 Palette: Add copy-to-clipboard button for contact email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+								<p><span class="email-text" data-user="sofia.dutta17" data-domain="gmail.com">sofia DOT dutta 17 AT gmail DOT com</span> <button class="btn btn-primary btn-outline btn-sm js-copy-email" type="button" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard3" aria-hidden="true"></i> Copy</button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,38 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').on('click', function(event){
+			event.preventDefault();
+			var $this = $(this);
+			var $emailSpan = $this.siblings('.email-text');
+			var email = $emailSpan.data('user') + '@' + $emailSpan.data('domain');
+
+			// Copy to clipboard
+			var $temp = $("<input>");
+			$("body").append($temp);
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			// Visual feedback
+			var originalHtml = '<i class="icon-clipboard3" aria-hidden="true"></i> Copy';
+			$this.html('<i class="icon-tick" aria-hidden="true"></i> Copied!');
+			$this.addClass('btn-success').removeClass('btn-primary btn-outline');
+
+			// Store timeout to clear it if clicked multiple times
+			if ($this.data('timeout')) {
+				clearTimeout($this.data('timeout'));
+			}
+
+			var timeout = setTimeout(function(){
+				$this.html(originalHtml);
+				$this.removeClass('btn-success').addClass('btn-primary btn-outline');
+			}, 2000);
+			$this.data('timeout', timeout);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +371,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
This PR adds a "Copy" button to the Contact section, allowing users to easily copy the email address despite it being obfuscated in the text to prevent scraping. It provides immediate visual feedback and adheres to the existing design system (Bootstrap 3, jQuery).

---
*PR created automatically by Jules for task [7727299180904203848](https://jules.google.com/task/7727299180904203848) started by @sofiadutta*