### PR TITLE
🛡️ Sentinel: Obfuscate email address to prevent scraping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-02-23 - Email Obfuscation on Static Site
+**Vulnerability:** Email harvesting via plain-text `mailto:` links on static HTML pages.
+**Learning:** Static sites lack server-side protections, so any exposed PII is vulnerable. Simple obfuscation using `data-` attributes and JS reconstruction is a lightweight defense that doesn't require backend changes.
+**Prevention:** Avoid `mailto:` links in raw HTML for public-facing emails. Use data attributes or contact forms.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" class="btn-hire js-email-protect" data-user="sofia.dutta17" data-domain="gmail.com">Hire me</a>
 									</div>
 								</div>
 							</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,15 @@
 		}
 	};
 
+	var emailProtect = function() {
+		$('.js-email-protect').on('click', function(event){
+			event.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			window.location.href = 'mailto:' + user + '@' + domain;
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +348,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailProtect();
 	});
 
 


### PR DESCRIPTION
🛡️ Sentinel: Obfuscate email address to prevent scraping

**Vulnerability:**
The contact email address was exposed in plain text within a `mailto:` link in `index.html`. This allows automated scrapers to easily harvest the email for spam.

**Fix:**
- Replaced the direct `href="mailto:..."` with `href="#"`.
- Added `data-user` and `data-domain` attributes to the "Hire me" button.
- Implemented a JavaScript function `emailProtect` in `js/main.js` that reconstructs the email address and opens the mail client only when the user clicks the button.

**Verification:**
- Verified via Playwright script that the `href` is `#` and the `data-` attributes are correct.
- Verified via screenshot that the button is visually correct and clickable.


---
*PR created automatically by Jules for task [370157904513844112](https://jules.google.com/task/370157904513844112) started by @sofiadutta*