### PR TITLE
Palette: Add Copy Email button for better UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,11 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Text-Transform CSS vs DOM Verification]
+**Learning:** UX verification scripts relying on `inner_text` can be misled by CSS `text-transform: uppercase`, which renders `Copied!` as `COPIED!`. DOM `text_content` holds the original case, while visual assertions must account for CSS.
+**Action:** When asserting button text in themes, check both rendered text (case-insensitive or expected case) and DOM content to ensure accessibility and visual correctness.
+
+## 2024-05-23 - [Clipboard API Fallback for Local Files]
+**Learning:** `navigator.clipboard.writeText` requires a secure context (HTTPS/localhost) and often fails when testing via `file://` protocol. A fallback using `document.execCommand('copy')` is essential for robustness in local testing environments.
+**Action:** Implement `document.execCommand('copy')` fallback when adding copy-to-clipboard features if local file testing is expected.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span class="email-text" data-user="sofia.dutta17" data-domain="gmail.com">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-primary btn-outline btn-sm js-copy-email" aria-label="Copy email address" style="margin-left: 10px;">Copy</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,61 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').on('click', function(e) {
+			e.preventDefault();
+			var $this = $(this);
+			var $emailText = $this.siblings('.email-text');
+			var user = $emailText.data('user');
+			var domain = $emailText.data('domain');
+			var email = user + '@' + domain;
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(email).then(function() {
+					$this.text('Copied!');
+					setTimeout(function() {
+						$this.text('Copy');
+					}, 2000);
+				}).catch(function(err) {
+					console.error('Could not copy text: ', err);
+					fallbackCopyTextToClipboard(email, $this);
+				});
+			} else {
+				fallbackCopyTextToClipboard(email, $this);
+			}
+		});
+	};
+
+	var fallbackCopyTextToClipboard = function(text, $btn) {
+		var textArea = document.createElement("textarea");
+		textArea.value = text;
+
+		// Avoid scrolling to bottom
+		textArea.style.top = "0";
+		textArea.style.left = "0";
+		textArea.style.position = "fixed";
+
+		document.body.appendChild(textArea);
+		textArea.focus();
+		textArea.select();
+
+		try {
+			var successful = document.execCommand('copy');
+			if (successful) {
+				$btn.text('Copied!');
+				setTimeout(function() {
+					$btn.text('Copy');
+				}, 2000);
+			} else {
+				console.error('Fallback: Copying text command was unsuccessful');
+			}
+		} catch (err) {
+			console.error('Fallback: Oops, unable to copy', err);
+		}
+
+		document.body.removeChild(textArea);
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +394,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
*   💡 What: Added a "Copy" button next to the email address in the Contact section.
*   🎯 Why: To allow users to easily copy the email address without manually decoding the obfuscated text.
*   📸 Before/After: The email address was previously static text "sofia DOT dutta ...". Now it includes a functional button that copies the correct email to clipboard.
*   ♿ Accessibility: Added `aria-label` to the button for screen readers. The button uses standard keyboard focus and provides visual feedback ("Copied!").

---
*PR created automatically by Jules for task [7993272939367160434](https://jules.google.com/task/7993272939367160434) started by @sofiadutta*