### PR TITLE
⚡ Bolt: Conditional preload for sidebar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-05-18 - Conditional Preloading for Off-Canvas Assets
+**Learning:** Large assets like `images/about.jpg` (2.9MB) are often preloaded unconditionally, wasting significant bandwidth on mobile devices where the sidebar containing the image is hidden/off-canvas.
+**Action:** Use `media` queries in `<link rel="preload">` tags (e.g., `media="(min-width: 769px)"`) to target only relevant viewports, ensuring large, non-critical assets are not downloaded unnecessarily on mobile.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload about.jpg only on desktop/tablet (min-width: 769px) to save bandwidth on mobile where sidebar is hidden -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the preload tag for `images/about.jpg`.
🎯 Why: The 2.9MB sidebar image was being preloaded unconditionally, consuming significant bandwidth on mobile devices where the sidebar is hidden by default.
📊 Impact: Reduces initial data transfer on mobile viewports by ~2.9MB.
🔬 Measurement: Verified using Playwright network interception; request is blocked on mobile (375px width) and allowed on desktop (1280px width).

---
*PR created automatically by Jules for task [2836438514683930994](https://jules.google.com/task/2836438514683930994) started by @sofiadutta*