### PR TITLE
⚡ Bolt: Conditionally preload large sidebar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-02-09 - Conditional Preloading for Sidebar Image
+**Learning:** The sidebar image `images/about.jpg` (2.9MB) was being preloaded unconditionally, causing massive bandwidth waste on mobile where the sidebar is hidden by default.
+**Action:** Used `media="(min-width: 769px)"` on the `<link rel="preload">` tag to restrict preloading to desktop viewports where the sidebar is visible. This is a high-impact, low-risk optimization for responsive sites with large assets in hidden-by-default components.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on larger screens to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Added `media="(min-width: 769px)"` to the preload tag for `images/about.jpg` to prevent downloading the 2.9MB image on mobile devices where the sidebar is hidden. This optimization saves bandwidth and improves initial load performance on mobile without affecting desktop experience.

---
*PR created automatically by Jules for task [13306962304995935117](https://jules.google.com/task/13306962304995935117) started by @sofiadutta*