### PR TITLE
🎨 Palette: Add copy-to-clipboard for contact email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<a href="mailto:sofia.dutta17@gmail.com">sofia.dutta17@gmail.com</a>
+										<button class="btn btn-sm btn-primary btn-outline js-copy-email" data-email="sofia.dutta17@gmail.com" title="Copy to clipboard" aria-label="Copy email address" style="margin-left: 10px; padding: 4px 10px !important; border-radius: 4px;">
+											<i class="icon-clipboard3"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,55 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').on('click', function(event) {
+			event.preventDefault();
+			var $this = $(this);
+			var email = $this.data('email');
+
+			var showSuccess = function() {
+				if ($this.data('timeout')) {
+					clearTimeout($this.data('timeout'));
+				}
+				$this.html('<i class="icon-tick"></i>');
+				var tId = setTimeout(function() {
+					$this.html('<i class="icon-clipboard3"></i>');
+				}, 2000);
+				$this.data('timeout', tId);
+			};
+
+			// Fallback for older browsers or non-secure contexts
+			if (!navigator.clipboard) {
+				var textArea = document.createElement("textarea");
+				textArea.value = email;
+				textArea.style.top = "0";
+				textArea.style.left = "0";
+				textArea.style.position = "fixed";
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+
+				try {
+					var successful = document.execCommand('copy');
+					if(successful) {
+						showSuccess();
+					}
+				} catch (err) {
+					console.error('Fallback: Unable to copy', err);
+				}
+
+				document.body.removeChild(textArea);
+				return;
+			}
+
+			navigator.clipboard.writeText(email).then(function() {
+				showSuccess();
+			}, function(err) {
+				console.error('Async: Could not copy text: ', err);
+			});
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +388,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
This PR improves the user experience of the Contact section by replacing the obfuscated email text with a clickable link and a "Copy to Clipboard" button.

### Changes:
- **`index.html`**: Replaced `<p>sofia DOT dutta...</p>` with a `mailto` link and a button using `icon-clipboard3`.
- **`js/main.js`**: Added `copyEmail` function which:
    - Uses `navigator.clipboard.writeText` for modern browsers.
    - Falls back to `document.execCommand('copy')` for compatibility.
    - Provides visual feedback (icon changes to tick) for 2 seconds.
    - Handles rapid clicks correctly to prevent the icon getting stuck in the "success" state.

### Verification:
- Verified visually using Playwright screenshots (ensuring the element is rendered correctly).
- Manual verification of the code logic.
- Checked against race conditions in the UI feedback loop.

---
*PR created automatically by Jules for task [7432157311485501695](https://jules.google.com/task/7432157311485501695) started by @sofiadutta*