### PR TITLE
⚡ Bolt: Optimize large image preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload about.jpg only on desktop to save bandwidth on mobile (2.9MB) -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 **What:** Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.

🎯 **Why:** The sidebar image `images/about.jpg` is 2.9MB. On mobile devices (viewport <= 768px), the sidebar is hidden off-screen by default. Preloading this massive asset blocks bandwidth for critical resources on mobile networks.

📊 **Impact:** Saves ~2.9MB of data transfer on initial load for mobile users.

🔬 **Measurement:** Verified with Playwright that the image request is initiated on desktop (1280x720) but suppressed on mobile (375x667).

---
*PR created automatically by Jules for task [14308507530426012137](https://jules.google.com/task/14308507530426012137) started by @sofiadutta*