### PR TITLE
🎨 Palette: Add Copy Email Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="email-address">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-primary btn-outline btn-xs js-copy-email" data-email="sofia.dutta17@gmail.com" aria-label="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,49 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').click(function(event) {
+			event.preventDefault();
+			var $this = $(this);
+			var email = $this.data('email');
+
+			var copyTextToClipboard = function(text) {
+				var textArea = document.createElement("textarea");
+				textArea.value = text;
+				textArea.style.position = "fixed";
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+				try {
+					document.execCommand('copy');
+				} catch (err) {}
+				document.body.removeChild(textArea);
+			};
+
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(email).then(function() {}, function() {
+					copyTextToClipboard(email);
+				});
+			} else {
+				copyTextToClipboard(email);
+			}
+
+			var originalHtml = $this.html();
+			$this.html('<i class="icon-tick"></i> Copied!');
+			$this.removeClass('btn-outline');
+
+			if ($this.data('timeout')) {
+				clearTimeout($this.data('timeout'));
+			}
+
+			var timeoutId = setTimeout(function() {
+				$this.html(originalHtml);
+				$this.addClass('btn-outline');
+			}, 2000);
+			$this.data('timeout', timeoutId);
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +382,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
Added a "Copy" button next to the email address in the contact section. This improves UX by allowing users to easily copy the email address without manually selecting the obfuscated text. The button provides visual feedback ("Copied!") upon interaction.

---
*PR created automatically by Jules for task [16726738228915468141](https://jules.google.com/task/16726738228915468141) started by @sofiadutta*