### PR TITLE
⚡ Bolt: optimize preload for sidebar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-08 - Conditional Preloading for Large Sidebar Image
+**Learning:** `images/about.jpg` (2.9MB) was being preloaded unconditionally, wasting bandwidth on mobile where the sidebar is hidden.
+**Action:** Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag. This ensures the asset is only preloaded on devices where it is likely to be visible (desktop), significantly improving initial load performance on mobile.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar profile photo only on desktop where it is visible (prevents 2.9MB download on mobile) -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the preload tag for `images/about.jpg`.
🎯 Why: `images/about.jpg` is a large 2.9MB asset that is part of the sidebar. The sidebar is hidden on mobile devices (viewport <= 768px). Unconditionally preloading it wastes bandwidth and delays other critical resources on mobile.
📊 Impact: Prevents 2.9MB download on initial load for mobile users, significantly improving performance.
🔬 Measurement: Verify `index.html` contains `<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">`.

---
*PR created automatically by Jules for task [10436606392917069759](https://jules.google.com/task/10436606392917069759) started by @sofiadutta*