### PR TITLE
⚡ Bolt: Optimize about.jpg preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload about image only on desktop where it's visible to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: The 2.9MB profile image is hidden by default on mobile (sidebar off-canvas) but was being unconditionally preloaded, wasting bandwidth.
📊 Impact: Saves ~2.9MB on initial page load for mobile devices.
🔬 Measurement: Verified with network interception that the request is skipped on mobile viewports (<769px) but remains on desktop. Visual verification confirmed the image still loads correctly when the sidebar is opened.

---
*PR created automatically by Jules for task [2124173942899857516](https://jules.google.com/task/2124173942899857516) started by @sofiadutta*