### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Clipboard API Fallback]
+**Learning:** Copying text to clipboard reliably across environments (secure/insecure context) requires checking `navigator.clipboard` first and falling back to `document.execCommand('copy')`.
+**Action:** Always wrap clipboard operations in a feature detection block and provide a robust fallback for legacy or local file environments.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<a href="mailto:sofia.dutta17@gmail.com">sofia.dutta17@gmail.com</a>
+										<button class="btn btn-primary btn-outline btn-sm js-copy-email" data-email="sofia.dutta17@gmail.com" aria-label="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,37 @@
 		}
 	};
 
+	var copyEmail = function() {
+		$('.js-copy-email').click(function(e) {
+			e.preventDefault();
+			var $this = $(this);
+			var email = $this.data('email');
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(email).then(success, fallback);
+			} else {
+				fallback();
+			}
+
+			function success() {
+				$this.html('<i class="icon-tick"></i> Copied!');
+				$this.removeClass('btn-primary').addClass('btn-success');
+				setTimeout(function() {
+					$this.html('<i class="icon-clipboard3"></i> Copy');
+					$this.removeClass('btn-success').addClass('btn-primary');
+				}, 2000);
+			}
+
+			function fallback() {
+				var temp = $('<input>');
+				$('body').append(temp);
+				temp.val(email).select();
+				try { document.execCommand('copy'); success(); } catch(e) {}
+				temp.remove();
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +370,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmail();
 	});
 
 


### PR DESCRIPTION
💡 What: Replaced the obfuscated email text with a functional `mailto:` link and a "Copy" button.
🎯 Why: To improve accessibility and usability for users wanting to contact the owner. The obfuscated text was a barrier.
📸 Before/After: Verified via Playwright screenshots.
♿ Accessibility: Added `aria-label` to the button and used semantic HTML.

---
*PR created automatically by Jules for task [919479185102867451](https://jules.google.com/task/919479185102867451) started by @sofiadutta*