### PR TITLE
⚡ Bolt: Conditionally preload sidebar profile image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-02-18 - Conditional Preloading for Large Assets
+**Learning:** `rel="preload"` is powerful but can be wasteful if unconditional. Large assets like sidebar images hidden on mobile (~2.9MB) should use the `media` attribute (e.g., `media="(min-width: 769px)"`) to prevent unnecessary downloads on constrained devices while maintaining performance for desktop users.
+**Action:** Always audit `preload` tags against the element's visibility across breakpoints. Use `media` queries in `<link>` tags for viewport-dependent assets.

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar profile image only on desktop (saves ~2.9MB on mobile) -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
*   💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.
*   🎯 Why: The 2.9MB profile image is only visible in the sidebar, which is hidden on mobile devices (viewport <= 768px). Unconditional preloading wastes significant bandwidth and delays LCP for mobile users.
*   📊 Impact: Saves ~2.9MB on initial mobile load. The image is lazy-loaded via existing JS when the mobile menu is opened.
*   🔬 Measurement: Verified with Playwright (`verify_preload.py`) that the request is skipped on mobile initial load and fired on menu open. Visual verification confirmed the image loads correctly when needed.

---
*PR created automatically by Jules for task [15887015347840260435](https://jules.google.com/task/15887015347840260435) started by @sofiadutta*