### PR TITLE
🎨 Palette: Add copy-to-clipboard button for contact email

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - Bootstrap Version Mismatch
+**Learning:** `package.json` dependencies can be misleading in legacy projects. This repo lists Bootstrap 5 but serves Bootstrap 3.3.5 css. Relying on modern utility classes (like `ms-2`) based on `package.json` led to incorrect assumptions.
+**Action:** Always verify the actual CSS file content (`head` links) before applying version-specific utility classes. When in doubt or constraints prevent custom CSS, use inline styles for micro-adjustments.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span>sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-primary btn-outline btn-sm js-email-copy" data-email="sofia.dutta17@gmail.com" aria-label="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,71 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.js-email-copy').on('click', function(event) {
+			event.preventDefault();
+			var $this = $(this);
+			var email = $this.data('email');
+
+			// Clear existing timeout
+			var timeout = $this.data('timeout');
+			if (timeout) {
+				clearTimeout(timeout);
+			}
+
+			var copySuccess = function() {
+				$this.removeClass('btn-primary btn-outline').addClass('btn-success');
+				$this.html('<i class="icon-tick"></i> Copied!');
+
+				var newTimeout = setTimeout(function() {
+					$this.removeClass('btn-success').addClass('btn-primary btn-outline');
+					$this.html('<i class="icon-clipboard3"></i> Copy');
+					$this.data('timeout', null);
+				}, 2000);
+
+				$this.data('timeout', newTimeout);
+			};
+
+			var copyFail = function(err) {
+				 console.error('Failed to copy: ', err);
+			};
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(email).then(copySuccess).catch(function(err) {
+					// Fallback
+					fallbackCopy(email);
+				});
+			} else {
+				fallbackCopy(email);
+			}
+
+			function fallbackCopy(text) {
+				var textArea = document.createElement("textarea");
+				textArea.value = text;
+
+				// Ensure it's not visible but part of DOM
+				textArea.style.position = "fixed";
+				textArea.style.left = "-9999px";
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+
+				try {
+					var successful = document.execCommand('copy');
+					if (successful) {
+						copySuccess();
+					} else {
+						copyFail('execCommand failed');
+					}
+				} catch (err) {
+					copyFail(err);
+				}
+
+				document.body.removeChild(textArea);
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +404,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
Added a "Copy" button next to the email address in the Contact section to improve UX. This allows users to copy the email easily despite it being obfuscated text.

Key changes:
- Modified `index.html` to add the button.
- Modified `js/main.js` to implement the copy logic with fallback and feedback animation.
- Verified visual appearance and functionality via Playwright.
- Verified compatibility with existing Bootstrap 3 styles.

---
*PR created automatically by Jules for task [4139131584334761108](https://jules.google.com/task/4139131584334761108) started by @sofiadutta*