### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,17 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="email-text">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-primary btn-outline btn-sm js-email-copy-btn"
+												data-user="sofia.dutta17"
+												data-domain="gmail.com"
+												aria-label="Copy email address to clipboard"
+												title="Copy email address"
+												style="margin-left: 10px;">
+											<i class="icon-clipboard3"></i> <span class="btn-text">Copy</span>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,85 @@
 		}
 	};
 
+	var initCopyEmail = function() {
+		function fallbackCopyTextToClipboard(text, onSuccess, onError) {
+			var textArea = document.createElement("textarea");
+			textArea.value = text;
+			textArea.style.position = "fixed";  // Avoid scrolling to bottom
+			document.body.appendChild(textArea);
+			textArea.focus();
+			textArea.select();
+
+			try {
+				var successful = document.execCommand('copy');
+				if (successful) {
+					onSuccess();
+				} else {
+					onError(new Error('Copy command failed'));
+				}
+			} catch (err) {
+				onError(err);
+			}
+			document.body.removeChild(textArea);
+		}
+
+		function copyTextToClipboard(text, onSuccess, onError) {
+			if (!navigator.clipboard) {
+				fallbackCopyTextToClipboard(text, onSuccess, onError);
+				return;
+			}
+			navigator.clipboard.writeText(text).then(function() {
+				onSuccess();
+			}, function(err) {
+				// Fallback if async copy fails
+				fallbackCopyTextToClipboard(text, onSuccess, onError);
+			});
+		}
+
+		function showCopySuccess($btn) {
+			var $icon = $btn.find('i');
+			var $text = $btn.find('.btn-text');
+			// Store original state if not already stored
+			if (!$btn.data('original-icon')) {
+				$btn.data('original-icon', $icon.attr('class'));
+				$btn.data('original-text', $text.text());
+			}
+
+			// Clear any existing timeout to prevent race conditions
+			if ($btn.data('timeout')) {
+				clearTimeout($btn.data('timeout'));
+			}
+
+			$icon.removeClass().addClass('icon-tick');
+			$text.text('Copied!');
+			$btn.removeClass('btn-primary').addClass('btn-success');
+
+			// Revert after 2 seconds
+			var timeoutId = setTimeout(function() {
+				$icon.removeClass().addClass($btn.data('original-icon'));
+				$text.text($btn.data('original-text'));
+				$btn.removeClass('btn-success').addClass('btn-primary');
+				$btn.removeData('timeout');
+			}, 2000);
+
+			$btn.data('timeout', timeoutId);
+		}
+
+		$('.js-email-copy-btn').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var user = $btn.data('user');
+			var domain = $btn.data('domain');
+			var email = user + '@' + domain;
+
+			copyTextToClipboard(email, function() {
+				showCopySuccess($btn);
+			}, function(err) {
+				console.error('Could not copy text: ', err);
+			});
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +418,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmail();
 	});
 
 


### PR DESCRIPTION
## 💡 What
Added a "Copy" button next to the contact email address.

## 🎯 Why
The email address was displayed as obfuscated text ("sofia DOT dutta..."), requiring manual transcription. This micro-interaction allows users to easily copy the correct email address with a single click.

## 📸 Before/After
- Before: Obfuscated text only.
- After: Semantic button with "Copy" label, aria-label, and visual feedback ("Copied!" with checkmark).

## ♿ Accessibility
- Added proper aria-labels to the button.
- Used semantic button element for keyboard focus.
- Ensures the copy action is accessible via keyboard.

---
*PR created automatically by Jules for task [1348700760338132563](https://jules.google.com/task/1348700760338132563) started by @sofiadutta*