### PR TITLE
⚡ Bolt: Conditionally preload sidebar image for desktop only

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Optimization: Only preload sidebar image on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the preload link for `images/about.jpg`.
🎯 Why: The 2.9MB sidebar image is hidden on mobile devices (<= 768px). Preloading it unconditionally wastes bandwidth and delays LCP on mobile.
📊 Impact: Saves ~2.9MB on initial load for mobile users.
🔬 Measurement: Verified the presence of the `media` attribute in `index.html`.

---
*PR created automatically by Jules for task [8949639828239480147](https://jules.google.com/task/8949639828239480147) started by @sofiadutta*