### PR TITLE
⚡ Bolt: Optimize preload for large sidebar image

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: `images/about.jpg` is a large asset (2.9MB) used in the sidebar. On mobile devices (<= 768px), the sidebar is hidden by default. Unconditional preloading wastes bandwidth and delays critical resource loading on mobile.
📊 Impact: Prevents 2.9MB download on initial load for mobile users. The image is lazily loaded when the user opens the sidebar menu.
🔬 Measurement: Verified using `verify_preload.py` (deleted) which confirmed no network request for the image on mobile viewport (375x812) and successful request on desktop viewport (1920x1080).

---
*PR created automatically by Jules for task [8896587769135341517](https://jules.google.com/task/8896587769135341517) started by @sofiadutta*