### PR TITLE
🎨 Palette: Add email copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Accessibility & Fallbacks]
+**Learning:** When dynamically changing icon content (e.g., success state), ensure `aria-hidden="true"` is preserved to avoid accessibility regressions. Also, for clipboard operations, using `document.execCommand('copy')` as a fallback ensures functionality in contexts where `navigator.clipboard` is restricted (e.g., `file://` or non-secure contexts).
+**Action:** Always include ARIA attributes in dynamic HTML strings and implement robust fallbacks for modern APIs like clipboard.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="email-text">sofia DOT dutta 17 AT gmail DOT com</span>&nbsp;<button class="btn btn-primary btn-outline btn-sm btn-copy-email" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address"><i class="icon-clipboard3" aria-hidden="true"></i> Copy</button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,69 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.btn-copy-email').click(function(event){
+			event.preventDefault();
+			var $this = $(this);
+			var user = $this.data('user');
+			var domain = $this.data('domain');
+			var email = user + '@' + domain;
+
+			// Clear any existing timeout to avoid race conditions
+			var existingTimeout = $this.data('timeout');
+			if (existingTimeout) {
+				clearTimeout(existingTimeout);
+			}
+
+			var successCallback = function() {
+				$this.html('<i class="icon-tick" aria-hidden="true"></i> Copied!');
+
+				var timeoutId = setTimeout(function(){
+					$this.html('<i class="icon-clipboard3" aria-hidden="true"></i> Copy');
+				}, 2000);
+
+				$this.data('timeout', timeoutId);
+			};
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(email).then(successCallback).catch(function(err) {
+					console.error('Async: Could not copy text: ', err);
+					// Fallback
+					fallbackCopyTextToClipboard(email);
+				});
+			} else {
+				fallbackCopyTextToClipboard(email);
+			}
+
+			function fallbackCopyTextToClipboard(text) {
+				var textArea = document.createElement("textarea");
+				textArea.value = text;
+
+				// Ensure textarea is not visible but part of DOM
+				textArea.style.position = "fixed";
+				textArea.style.left = "-9999px";
+				textArea.style.top = "0";
+
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+
+				try {
+					var successful = document.execCommand('copy');
+					if (successful) {
+						successCallback();
+					} else {
+						console.error('Fallback: Copying text command was unsuccessful');
+					}
+				} catch (err) {
+					console.error('Fallback: Oops, unable to copy', err);
+				}
+
+				document.body.removeChild(textArea);
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +402,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
This PR adds a "Copy" button next to the email address in the contact section. This improves UX by allowing users to easily copy the email address instead of manually typing it from the obfuscated text.

Changes:
- Modified `index.html`: Added button structure with data attributes for email parts.
- Modified `js/main.js`: Added logic to handle click, reconstruct email, copy to clipboard, and provide temporary visual feedback.
- Ensured accessibility by preserving `aria-hidden="true"` on icons and using ARIA labels.
- Verified functionality and fallback mechanism using Playwright.


---
*PR created automatically by Jules for task [4695221936608365870](https://jules.google.com/task/4695221936608365870) started by @sofiadutta*