### PR TITLE
⚡ Bolt: Optimize preload for large sidebar image

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload about image only on desktop to save bandwidth on mobile -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` attribute to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: The `about.jpg` image is 2.9MB and located in the sidebar, which is hidden off-canvas on mobile devices (viewport <= 768px). Preloading it unconditionally wastes massive bandwidth on mobile.
📊 Impact: Saves ~2.9MB of data on initial load for mobile users.
🔬 Measurement: Verified by inspecting the `index.html` tag attributes using a custom script `verify_preload.py` (deleted after verification).

---
*PR created automatically by Jules for task [18135940274594242174](https://jules.google.com/task/18135940274594242174) started by @sofiadutta*