### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2026-02-23 - Legacy Clipboard Copy Pattern
+**Learning:** In legacy environments (jQuery, HTTP) lacking `navigator.clipboard`, `document.execCommand('copy')` with a temporary textarea remains the most robust solution. Visual feedback requires explicit class swapping (`.btn-primary` <-> `.btn-success`) and icon toggling (`.icon-clipboard3` <-> `.icon-tick`) due to CSS specificity issues in Bootstrap 3 themes.
+**Action:** Use the `emailCopy` implementation as a template for future copy-to-clipboard features, ensuring `aria-hidden` is preserved on icons and timeout handlers are cleared to prevent race conditions.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,13 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="email-text">sofia DOT dutta 17 AT gmail DOT com</span>&nbsp;
+										<button class="btn btn-primary btn-sm btn-outline js-email-copy" aria-label="Copy email address" data-user="sofia.dutta17" data-domain="gmail.com">
+											<i class="icon-clipboard3" aria-hidden="true"></i>
+											<span class="btn-text">Copy</span>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,43 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.js-email-copy').click(function(event) {
+			event.preventDefault();
+			var $this = $(this);
+			var user = $this.data('user');
+			var domain = $this.data('domain');
+			var email = user + '@' + domain;
+
+			// Copy using temporary textarea
+			var $temp = $("<textarea>");
+			$("body").append($temp);
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			// Visual feedback
+			$this.removeClass('btn-primary').addClass('btn-success');
+			$this.find('i').removeClass('icon-clipboard3').addClass('icon-tick');
+			$this.find('.btn-text').text('Copied!');
+
+			// Clear existing timeout if any
+			var timeout = $this.data('timeout');
+			if (timeout) {
+				clearTimeout(timeout);
+			}
+
+			// Revert after 2 seconds
+			timeout = setTimeout(function() {
+				$this.removeClass('btn-success').addClass('btn-primary');
+				$this.find('i').removeClass('icon-tick').addClass('icon-clipboard3');
+				$this.find('.btn-text').text('Copy');
+			}, 2000);
+
+			$this.data('timeout', timeout);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +376,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a "Copy" button next to the email address in the contact section.
🎯 Why: Users previously had to manually copy and fix the obfuscated "sofia DOT dutta..." text. This micro-UX improvement makes it one-click easy while keeping the email hidden from simple scrapers.
📸 Before/After: Verified via screenshots (button appears next to text, changes to green "Copied!" state on click).
♿ Accessibility: Button has `aria-label`, icon changes use `aria-hidden`, and keyboard interaction works via standard button behavior.

---
*PR created automatically by Jules for task [16556755653881712028](https://jules.google.com/task/16556755653881712028) started by @sofiadutta*