### PR TITLE
Add Copy-to-Clipboard for Email and Obfuscate Mailto Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" class="btn-hire js-email-protect" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Email me">Hire me</a>
 									</div>
 								</div>
 							</div>
@@ -861,7 +861,13 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="email-text">sofia DOT dutta 17 AT gmail DOT com</span>
+										&nbsp;
+										<button class="btn btn-sm btn-outline btn-primary js-email-copy" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,47 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.js-email-copy').click(function(event){
+			event.preventDefault();
+			var $btn = $(this);
+			var user = $btn.data('user');
+			var domain = $btn.data('domain');
+			var email = user + '@' + domain;
+
+			var $temp = $("<textarea>");
+			$("body").append($temp);
+			$temp.val(email).select();
+			document.execCommand("copy");
+			$temp.remove();
+
+			$btn.html('<i class="icon-tick"></i> Copied!');
+			$btn.removeClass('btn-primary btn-outline').addClass('btn-success');
+
+			if ($btn.data('timeout')) {
+				clearTimeout($btn.data('timeout'));
+			}
+
+			var timeoutId = setTimeout(function(){
+				$btn.html('<i class="icon-clipboard"></i> Copy');
+				$btn.removeClass('btn-success').addClass('btn-primary btn-outline');
+				$btn.data('timeout', null);
+			}, 2000);
+
+			$btn.data('timeout', timeoutId);
+		});
+	};
+
+	var emailProtect = function() {
+		$('.js-email-protect').click(function(event){
+			event.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			var email = user + '@' + domain;
+			window.location.href = 'mailto:' + email;
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +380,8 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
+		emailProtect();
 	});
 
 


### PR DESCRIPTION
- Replaced hardcoded email text with a span and a "Copy" button in the contact section to improve usability.
- The button copies the reconstructed email to the clipboard and gives visual feedback ("Copied!") using existing theme styles.
- Obfuscated the "Hire me" button's `href` to prevent simple scraping, handling the click via JavaScript to generate the `mailto:` link dynamically.
- Added `emailCopy` and `emailProtect` functions to `js/main.js` to handle these interactions.
- Verified changes with Playwright scripts and screenshots, ensuring no regressions in existing functionality.

---
*PR created automatically by Jules for task [8350405933800233146](https://jules.google.com/task/8350405933800233146) started by @sofiadutta*