### PR TITLE
⚡ Bolt: Optimize large image preloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop (saves 3MB on mobile) -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
⚡ Bolt: Optimize large image preloading

💡 What: Added a `media` attribute to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: The 2.9MB sidebar image was being preloaded on all devices, even mobile (viewport < 769px) where it is hidden by CSS.
📊 Impact: Saves ~3MB of bandwidth for mobile users.
🔬 Measurement: Verified using `verify_preload.py` (syntax) and visual inspection of mobile screenshots to ensure no regressions.

---
*PR created automatically by Jules for task [3728272317964914166](https://jules.google.com/task/3728272317964914166) started by @sofiadutta*