### PR TITLE
⚡ Bolt: optimize large asset preload for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop/tablet where it is visible -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Added media attribute to images/about.jpg preload to prevent downloading 2.9MB image on mobile devices where sidebar is hidden.

---
*PR created automatically by Jules for task [12082240724085265100](https://jules.google.com/task/12082240724085265100) started by @sofiadutta*