### PR TITLE
🎨 Palette: Add copy-to-clipboard button for email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,13 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span>sofia DOT dutta 17 AT gmail DOT com</span>
+										&nbsp;
+										<button class="btn btn-primary btn-outline btn-sm js-email-copy" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address" title="Copy email address">
+											Copy <i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,38 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.js-email-copy').click(function(event) {
+			event.preventDefault();
+			var $this = $(this);
+
+			// Prevent rapid clicking while showing success state
+			if ($this.hasClass('btn-success')) {
+				return;
+			}
+
+			var user = $this.data('user');
+			var domain = $this.data('domain');
+			var email = user + '@' + domain;
+
+			// Copy to clipboard
+			var tempInput = $('<textarea>');
+			$('body').append(tempInput);
+			tempInput.val(email).select();
+			document.execCommand('copy');
+			tempInput.remove();
+
+			var originalText = $this.html();
+			$this.html('Copied! <i class="icon-check" aria-hidden="true"></i>');
+			$this.addClass('btn-success').removeClass('btn-primary btn-outline');
+
+			setTimeout(function() {
+				$this.html(originalText);
+				$this.removeClass('btn-success').addClass('btn-primary btn-outline');
+			}, 2000);
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +371,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
💡 **What:** Added a "Copy" button next to the email address in the contact section.
🎯 **Why:** The email address was previously displayed as obfuscated text (`sofia DOT dutta...`), which required manual typing or reconstruction by the user. This micro-interaction allows users to easily copy the correct email address while keeping the text obfuscated for scrapers.
📸 **Before/After:** The email display now includes an interactive button that changes state to "Copied!" with a checkmark upon clicking.
♿ **Accessibility:** The button includes an `aria-label` and the icon is hidden from screen readers.


---
*PR created automatically by Jules for task [17181088974262451874](https://jules.google.com/task/17181088974262451874) started by @sofiadutta*