### PR TITLE
⚡ Bolt: Conditionally preload large sidebar image

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 	<link rel="shortcut icon" href="favicon.ico">
 
-	<link rel="preload" as="image" href="images/about.jpg">
+	<!-- Preload sidebar image only on desktop to save mobile bandwidth -->
+	<link rel="preload" as="image" href="images/about.jpg" media="(min-width: 769px)">
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
💡 What: Added `media="(min-width: 769px)"` to the `<link rel="preload">` tag for `images/about.jpg`.
🎯 Why: The `about.jpg` image is 2.9MB and located in the sidebar, which is hidden by default on mobile devices (<= 768px). Preloading it unconditionally wastes bandwidth on mobile.
📊 Impact: Reduces initial data transfer by ~2.9MB on mobile devices, significantly improving LCP and TTI for those users.
🔬 Measurement: Verified that the `media` attribute is present in `index.html` and correctly targets desktop viewports.

---
*PR created automatically by Jules for task [12031996689849294765](https://jules.google.com/task/12031996689849294765) started by @sofiadutta*