### PR TITLE
⚡ Bolt: Optimize scroll event listener

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+
+## 2025-01-08 - UX Considerations with Scroll Debouncing
+**Learning:** While `debounce` is useful for saving CPU cycles, applying it to immediate visual updates (like closing a menu on scroll) causes a noticeable delay and poor UX because it waits for the scroll to *stop* before firing.
+**Action:** For continuous events tied to immediate visual feedback, use `window.requestAnimationFrame` with a throttling boolean flag (e.g., `ticking = false;`) instead of a traditional debounce. This ensures the update happens smoothly within the browser's render cycle without blocking the main thread.

--- a/js/main.js
+++ b/js/main.js
@@ -149,13 +149,24 @@
 	    }
 		});
 
-		$(window).scroll(function(){
-			if ( $('body').hasClass('offcanvas') ) {
+		// Optimize scroll handler: Cache the body and nav toggle elements outside the scroll event.
+		// Use requestAnimationFrame or a simple throttle instead of debounce to ensure instant UX feedback
+		// without completely blocking the main thread during heavy scrolling.
+		var $body = $('body');
+		var $navToggle = $('.js-colorlib-nav-toggle');
+		var ticking = false;
 
-    			$('body').removeClass('offcanvas');
-    			$('.js-colorlib-nav-toggle').removeClass('active');
-			
-	    	}
+		$(window).scroll(function() {
+			if (!ticking) {
+				window.requestAnimationFrame(function() {
+					if ( $body.hasClass('offcanvas') ) {
+						$body.removeClass('offcanvas');
+						$navToggle.removeClass('active');
+					}
+					ticking = false;
+				});
+				ticking = true;
+			}
 		});
 
 	};
@@ -190,9 +201,7 @@
 
 		var $el = $('#navbar > ul');
 		$el.find('li').removeClass('active');
-		$el.each(function(){
-			$(this).find('a[data-nav-section="'+section+'"]').closest('li').addClass('active');
-		});
+		$el.find('a[data-nav-section="'+section+'"]').closest('li').addClass('active');
 
 	};
 


### PR DESCRIPTION
## ⚡ Bolt: Optimize scroll event listener

- **💡 What**: Optimized the `mobileMenuOutsideClick` scroll event by caching `$body` and `$navToggle` elements. Throttle the event using `window.requestAnimationFrame` instead of firing on every scroll tick. Simplified `navActive` execution by replacing the redundant `.each()` loop with a direct `.find()` chain.
- **🎯 Why**: 
  1. Continually running jQuery selectors like `$('body')` inside a `scroll` event handler can cause severe frame drops (jank), as it runs dozens of times per second.
  2. The `.each()` loop over `$el` (which only selects one `#navbar > ul`) was creating an unnecessary function closure and iteration cycle.
- **📊 Impact**: Prevents blocking the main thread during heavy scrolling. Decreases garbage collection overhead by eliminating repetitive jQuery object instantiations. Guarantees smooth off-canvas menu closing.
- **🔬 Measurement**: Scroll down the page with Chrome DevTools Performance Profile running. Observe fewer "Recalculate Style" and "Layout" forced synchronous warnings compared to the previous state.

---
*PR created automatically by Jules for task [17558150649122443395](https://jules.google.com/task/17558150649122443395) started by @sofiadutta*