### PR TITLE
🎨 Palette: Add copy button to email in contact section

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Visual Feedback for Copy Actions]
+**Learning:** Providing real-time visual feedback ("Copied!") when clicking a copy button significantly improves UX for all users by giving them confidence the action occurred. However, dynamically restoring the button's HTML content after a timeout can introduce security risks if not done carefully.
+**Action:** Temporarily changing the button text (with a timeout) when a user performs a specific action such as copying a URL/email is a great pattern. However, do not use jQuery's `.html()` to restore the original button state to avoid XSS vulnerabilities or creating accessibility regressions. Instead, use `.text()` on specific text nodes or hide/show existing child elements (like icons) safely.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>sofia DOT dutta 17 AT gmail DOT com&nbsp;&nbsp;<button class="btn btn-primary btn-sm js-email-copy" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard js-email-copy-icon" aria-hidden="true"></i><span class="js-email-copy-text"> Copy</span></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,44 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('.js-email-copy').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var user = $btn.attr('data-user');
+			var domain = $btn.attr('data-domain');
+			var email = user + '@' + domain;
+
+			var setCopiedState = function() {
+				$btn.find('.js-email-copy-icon').hide();
+				$btn.find('.js-email-copy-text').text('Copied!');
+				setTimeout(function() {
+					$btn.find('.js-email-copy-icon').show();
+					$btn.find('.js-email-copy-text').text(' Copy');
+				}, 2000);
+			};
+
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(email).then(setCopiedState);
+			} else {
+				var textArea = document.createElement("textarea");
+				textArea.value = email;
+				textArea.style.position = "absolute";
+				textArea.style.left = "-9999px";
+				textArea.style.top = "-9999px";
+				document.body.appendChild(textArea);
+				textArea.select();
+				try {
+					document.execCommand('copy');
+					setCopiedState();
+				} catch (err) {
+					console.error('Fallback: Oops, unable to copy', err);
+				}
+				document.body.removeChild(textArea);
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +377,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
💡 **What:** Added a "Copy" button next to the email address in the contact section that copies the actual email address to the clipboard. The button provides visual feedback by temporarily changing to "Copied!".
🎯 **Why:** To make it easier for users to contact Sofia without having to manually copy and correct the obfuscated email address ("sofia DOT dutta 17 AT gmail DOT com").
📸 **Before/After:** See frontend verification screenshot.
♿ **Accessibility:** Added an `aria-label` and `title` to the button for screen reader support and native browser tooltips. The icon's `aria-hidden` attribute is properly preserved during state transitions.

---
*PR created automatically by Jules for task [7642237895192882936](https://jules.google.com/task/7642237895192882936) started by @sofiadutta*