### PR TITLE
🛡️ Sentinel: Add sandbox attributes to iframe embeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+## 2025-03-04 - Defense-in-depth for iframe embeds
+**Vulnerability:** Embedded third-party content (e.g., YouTube `iframe`) could potentially execute unauthorized top-level navigation, or perform other malicious actions.
+**Learning:** Enforcing defense-in-depth security by adding a restrictive `sandbox` attribute (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) to `iframe` elements is a simple and effective security enhancement.
+**Prevention:** Always add a `sandbox` attribute with appropriate restrictions when embedding third-party content via `iframe`.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Embedded third-party content (e.g., YouTube `iframe`) could potentially execute unauthorized top-level navigation, or perform other malicious actions due to missing restrictions.
🎯 Impact: Exploiting these iframes could lead to XSS breakouts, popups, or unwanted navigation in the context of the user's browser viewing the site.
🔧 Fix: Added a restrictive `sandbox` attribute (`allow-scripts allow-same-origin allow-presentation allow-popups`) to `iframe` elements in `index.html`. This follows the principle of defense-in-depth by enforcing least privilege on embedded content while maintaining expected functionality (playing videos, fullscreen, and navigating to YouTube). Also recorded the learning in `.jules/sentinel.md` and included a trivial fix for copyright text formatting to ensure existing regression tests pass.
✅ Verification: Ran `verify_changes.py` and `verify_resize.py` to verify that existing functionality works correctly and the layout is not broken. Checked `index.html` to confirm that the sandbox attributes are correctly applied to the iframe elements.

---
*PR created automatically by Jules for task [9722808964470311125](https://jules.google.com/task/9722808964470311125) started by @sofiadutta*