### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attributes to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-02-19 - Third-Party iframe security
+**Vulnerability:** Third-party content embedded via `iframe` (such as YouTube videos) didn't have sandbox restrictions, posing a potential risk of unauthorized top-level navigation and XSS breakouts.
+**Learning:** For defense-in-depth, even if the third party is currently trusted (like YouTube), their scripts could change. Any embedded external content requires strict boundary enforcement.
+**Prevention:** Always add restrictive `sandbox` attributes (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) to `iframe` elements to prevent XSS breakouts and unauthorized top-level navigation.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Third-party content embedded via `iframe` (like the YouTube demo videos) lacked restrictive security boundaries (`sandbox`). Even with currently trusted providers, omitting these controls poses a theoretical risk of unauthorized top-level navigation, prompt spoofing, or XSS breakouts if the provider's scripts change or are compromised.
🎯 **Impact:** Prevents malicious scripts inside the iframe from breaking out, reading top-level cookies, or forcing navigation away from the portfolio site.
🔧 **Fix:** Added the `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attribute to both `<iframe src="https://www.youtube.com/embed/...">` tags in `index.html`. This follows the principle of defense-in-depth, allowing necessary functionality for video playback while enforcing strict boundaries. Added learning to `.jules/sentinel.md`.
✅ **Verification:**
1. Confirmed both YouTube videos still load and play correctly (presentation and scripts allowed).
2. Fullscreen and popups (e.g., clicking to watch on YouTube directly) function as expected.
3. Verified via Playwright tests (`verify_changes.py`) that the DOM structure, copyright format, and layout (`verify_resize.py`) remained unaffected.

---
*PR created automatically by Jules for task [14145613422880763401](https://jules.google.com/task/14145613422880763401) started by @sofiadutta*