### PR TITLE
🛡️ Sentinel: Add restrictive sandbox attributes to third-party iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
**🚨 Severity:** ENHANCEMENT
**💡 Vulnerability:** Third-party iframes (like YouTube embeds) were implemented without restrictive `sandbox` attributes. This could potentially allow the embedded content to execute arbitrary actions, such as attempting unauthorized top-level navigation, breaking out of frames, or executing malicious scripts that interfere with the parent document.
**🎯 Impact:** By default, iframes grant the embedded content significant privileges. Restricting these privileges with the `sandbox` attribute follows the principle of least privilege, providing defense-in-depth against Cross-Site Scripting (XSS) and unwanted behavior from third-party sources.
**🔧 Fix:** Added the `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attribute to all YouTube `<iframe ...>` elements in `index.html`. This ensures the embedded video player functions correctly (requiring scripts, same-origin access for API functionality, presentation mode, and popups for external links) while denying other potentially dangerous permissions like `allow-top-navigation`.
**✅ Verification:**
- Checked out the changes and visually confirmed via Playwright verification screenshots that video thumbnails and structure load without errors.
- Ran `python3 verify_changes.py` and `python3 verify_resize.py` to ensure no visual regressions in existing elements.

---
*PR created automatically by Jules for task [3362113841969683398](https://jules.google.com/task/3362113841969683398) started by @sofiadutta*