### PR TITLE
🎨 Palette: Add copy-to-clipboard functionality for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Obfuscated Email Copy UX]
+**Learning:** Found an obfuscated email string that forced users to manually copy and edit it to send an email. For intentionally obfuscated data, putting the raw string in a data attribute defeats the obfuscation. Instead, read the text dynamically and de-obfuscate it client-side inside the event listener.
+**Action:** When adding copy-to-clipboard functionality to obfuscated strings, de-obfuscate the content at runtime rather than storing it in plain text in the HTML.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="margin-left: 10px; padding: 2px 10px;">
+											<i class="icon-clipboard3" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,50 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('#copy-email-btn').on('click', function(e) {
+			e.preventDefault();
+			var btn = $(this);
+			var originalHTML = '<i class="icon-clipboard3" aria-hidden="true"></i> Copy';
+			var successHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+
+			// Read the obfuscated string dynamically from the DOM
+			var obfuscatedText = $('#obfuscated-email').text();
+			// De-obfuscate the string client-side
+			var cleanEmail = obfuscatedText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s+/g, '');
+
+			// Try using the modern Clipboard API
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(cleanEmail).then(function() {
+					btn.html(successHTML);
+					setTimeout(function() { btn.html(originalHTML); }, 2000);
+				});
+			} else {
+				// Fallback for older browsers
+				var textArea = document.createElement("textarea");
+				textArea.value = cleanEmail;
+				textArea.style.position = "absolute";
+				textArea.style.left = "-9999px";
+				textArea.style.top = "-9999px";
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+
+				try {
+					var successful = document.execCommand('copy');
+					if (successful) {
+						btn.html(successHTML);
+						setTimeout(function() { btn.html(originalHTML); }, 2000);
+					}
+				} catch (err) {
+					console.error('Fallback: Oops, unable to copy', err);
+				}
+
+				document.body.removeChild(textArea);
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +383,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
### 💡 What
Added a "Copy" button next to the obfuscated email address in the Contact section that automatically reads the obfuscated string, cleans it up client-side, and securely copies it to the user's clipboard. Also includes a temporary "Copied!" state for visual feedback.

### 🎯 Why
Previously, the obfuscated email (`sofia DOT dutta 17 AT gmail DOT com`) forced users to manually select, copy, paste, and edit the string to send an email. This is a high-friction UX pattern. The new copy button eliminates this friction entirely while still preserving the basic obfuscation against simple scraping bots (by performing the de-obfuscation only within the click handler at runtime).

### ♿ Accessibility Improvements
*   Added `aria-label` and `title` to the new icon button to ensure it is fully understandable by screen reader users and provides native tooltips for sighted mouse users.
*   Ensured visual feedback ("Copied!") does not rely on changing button colors that might violate contrast rules, preserving the standard primary button style.
*   The fallback clipboard script uses an off-screen, absolute-positioned textarea to prevent the screen from jarringly scrolling to the bottom of the page when the hidden field is focused during execution.

### 📸 Before/After
*   **Before:** Just plain obfuscated text.
*   **After:** Text with a handy "Copy" button that dynamically switches state on click.

---
*PR created automatically by Jules for task [8032299523234174461](https://jules.google.com/task/8032299523234174461) started by @sofiadutta*