### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attributes to iframe embeds for defense-in-depth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2026-03-11 - Add Sandbox attributes to iframes
+**Vulnerability:** Third-party iframes (like YouTube embeds) missing restrictive sandbox attributes, which could allow XSS breakouts or unauthorized top-level navigation.
+**Learning:** Even well-known third-party embeds should be sandboxed to enforce defense-in-depth security.
+**Prevention:** Always add restrictive sandbox attributes (e.g., allow-scripts allow-same-origin allow-presentation allow-popups) to iframes.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Third-party iframes (like YouTube embeds) were missing restrictive `sandbox` attributes. This could allow potential XSS breakouts or unauthorized top-level navigation if the embedded content were ever compromised.
🎯 **Impact:** Exploitation could lead to malicious scripts breaking out of the iframe context and interacting with the main site or redirecting the user.
🔧 **Fix:** Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to the YouTube `iframe` tags in `index.html`. This enforces the principle of least privilege while maintaining the core functionality of the video player.
✅ **Verification:** 
- Verified using a headless Playwright script (`/home/jules/verification/verify_iframes.py`) that the `sandbox` attributes are correctly applied to the targeted `iframe` elements.
- Ran tracked regression tests (`verify_changes.py` and `verify_resize.py`), ensuring no existing layout or content checks were broken.
- Documented learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5696702063490315948](https://jules.google.com/task/5696702063490315948) started by @sofiadutta*