### PR TITLE
🎨 Palette: Add one-click copy functionality for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2026-03-13 - [Secure Micro-UX for Copying Obfuscated Data]
+**Learning:** Implementing 'copy to clipboard' functionality for obfuscated data requires client-side de-obfuscation rather than storing raw text in data attributes, which would defeat the obfuscation. Additionally, dynamically updating button states using raw jQuery '.html()' with 'data-original-text' triggers CodeQL XSS vulnerabilities.
+**Action:** Use hardcoded safe HTML strings for temporary state changes instead of storing/restoring DOM elements, and ensure fallback clipboard implementations use positioned-off-screen textareas to avoid jank.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,8 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy Email" title="Copy Email">Copy Email <i class="icon-mail6" aria-hidden="true"></i></button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,39 @@
 		}
 	};
 
+	var emailCopy = function() {
+		$('#copy-email-btn').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var rawText = $('#obfuscated-email').text();
+			var email = rawText.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+			var onSuccess = function() {
+				$btn.html('<i class="icon-check" aria-hidden="true"></i> Copied!');
+				setTimeout(function() {
+					$btn.html('Copy Email <i class="icon-mail6" aria-hidden="true"></i>');
+				}, 2000);
+			};
+
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(email).then(onSuccess, function(err) {
+					console.error('Failed to copy email:', err);
+				});
+			} else {
+				var $temp = $("<textarea>");
+				$("body").append($temp);
+				$temp.css({position: "absolute", left: "-9999px", top: "-9999px"}).val(email).select();
+				try {
+					document.execCommand("copy");
+					onSuccess();
+				} catch (err) {
+					console.error('Failed to copy email (fallback):', err);
+				}
+				$temp.remove();
+			}
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -338,6 +371,7 @@
 		sliderMain();
 		stickyFunction();
 		lazyLoadBackgrounds();
+		emailCopy();
 		updateCopyrightYear();
 	});
 


### PR DESCRIPTION
💡 What: Added a "Copy Email" button next to the obfuscated email address that de-obfuscates the text client-side and copies it to the clipboard, providing a temporary "Copied!" feedback state.
🎯 Why: Users cannot easily copy the email address because it contains obfuscating text (" DOT " and " AT "). Forcing users to manually reformat the text is a poor experience. This provides a one-click solution.
♿ Accessibility: The button includes an `aria-label` and `title` tooltip to explain its purpose. Instead of changing the button class to a green "success" button (which has poor contrast with white text in this template), the primary button style is maintained to preserve readability, updating only the inner icon and text.

---
*PR created automatically by Jules for task [15592539344355692069](https://jules.google.com/task/15592539344355692069) started by @sofiadutta*