### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox to YouTube iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2026-03-14 - Adding iframe sandboxing
+**Vulnerability:** YouTube iframe embeds without a sandbox attribute can be a security risk as they could allow XSS breakouts or unauthorized top-level navigation.
+**Learning:** Always apply defense-in-depth by restricting iframe capabilities to only those necessary.
+**Prevention:** Use the `sandbox` attribute with appropriate values like `allow-scripts allow-same-origin allow-presentation allow-popups`.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Embedded YouTube `iframe`s did not have a `sandbox` attribute. While YouTube is generally trusted, embedding third-party content without restrictions is a security risk as it could theoretically allow XSS breakouts, unauthorized top-level navigation, or popups if the embedded content were compromised or if it served malicious ads.
🎯 Impact: Prevents potential XSS breakouts and unauthorized top-level navigation from embedded third-party content, applying defense-in-depth.
🔧 Fix: Added the `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attribute to the two YouTube `iframe` elements in `index.html`. This allows necessary functionality (like playing the video and scripts) while restricting potentially dangerous capabilities.
✅ Verification: Checked the `index.html` file to ensure the `sandbox` attribute is present on the correct `iframe` tags. Ran `verify_changes.py` and `verify_resize.py` to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [5913524315647135295](https://jules.google.com/task/5913524315647135295) started by @sofiadutta*