### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attributes to iframe embeds for defense-in-depth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-03-15 - Third-Party Iframe Sandbox
+**Vulnerability:** Third-party iframes (e.g., YouTube embeds) were embedded without a `sandbox` attribute, allowing potential top-level navigation hijacks or XSS breakouts if the third-party domain is compromised.
+**Learning:** The `sandbox` attribute provides critical defense-in-depth by restricting the capabilities of embedded content.
+**Prevention:** Always include restrictive `sandbox` attributes (like `allow-scripts allow-same-origin allow-presentation allow-popups`) on third-party `iframe` embeds to prevent malicious breakouts and unauthorized redirects.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability
Third-party `iframe` elements (e.g., YouTube video embeds) in `index.html` were embedded without `sandbox` attributes. If a third-party domain is compromised, the lack of sandboxing allows embedded content to execute malicious scripts that could potentially attempt to break out of the iframe, execute unauthorized redirects, or hijack the top-level window.

### 🎯 Impact
Without restrictions, malicious content from an iframe could navigate the parent window to a phishing site or attempt to access sensitive parent-context data (though CORS and same-origin policies typically mitigate the latter, `sandbox` provides necessary defense-in-depth).

### 🔧 Fix
Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to both YouTube video `iframe` elements. This explicitly restricts what the embedded content can do. It prevents the embedded frame from navigating the top-level window while still allowing necessary functionality like video playback, popups (e.g., for sharing/external links), and full-screen presentation.

Also updated the `.jules/sentinel.md` journal to document this learning as instructed.

### ✅ Verification
1. Run `python3 verify_changes.py` and `python3 verify_resize.py` to ensure core site behavior and responsiveness are unaffected.
2. Manually open `index.html` and verify the embedded YouTube videos still play and can be expanded to full screen.

---
*PR created automatically by Jules for task [5780352740079702587](https://jules.google.com/task/5780352740079702587) started by @sofiadutta*