### PR TITLE
🎨 Palette: Add copy to clipboard button for email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2026-03-15 - [De-obfuscating Email for Clipboard UX]
+**Learning:** When obfuscating an email address for anti-spam (e.g., 'foo DOT bar AT baz DOT com'), it creates friction for users wanting to copy it. Adding a copy button that de-obfuscates client-side before placing it in the clipboard (stripping spaces, replacing 'DOT' and 'AT') provides the best of both worlds: spam protection and good UX.
+**Action:** Use `navigator.clipboard.writeText` combined with string manipulation (e.g., `.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@')`) when implementing copy functionality for intentionally obfuscated text. Avoid storing the raw string in `data-*` attributes, which defeats the obfuscation.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email" style="display: inline-block; margin-right: 10px;">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="padding: 2px 10px;">
+										<i class="icon-clipboard3" aria-hidden="true"></i>
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,61 @@
 		}
 	};
 
+	var emailCopy = function() {
+		var btn = $('#copy-email-btn');
+		var emailTextElem = $('#obfuscated-email');
+
+		if (btn.length > 0 && emailTextElem.length > 0) {
+			btn.on('click', function() {
+				var obfuscatedText = emailTextElem.text();
+				var email = obfuscatedText.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var copySuccess = function() {
+					var originalHtml = btn.html();
+					var originalTitle = btn.attr('title');
+					var originalAriaLabel = btn.attr('aria-label');
+
+					btn.html('<i class="icon-check" aria-hidden="true"></i>');
+					btn.attr('title', 'Copied!');
+					btn.attr('aria-label', 'Copied!');
+
+					setTimeout(function() {
+						btn.html(originalHtml);
+						btn.attr('title', originalTitle);
+						btn.attr('aria-label', originalAriaLabel);
+					}, 2000);
+				};
+
+				if (navigator.clipboard && navigator.clipboard.writeText) {
+					navigator.clipboard.writeText(email).then(copySuccess).catch(function(err) {
+						console.error('Could not copy text: ', err);
+					});
+				} else {
+					// Fallback
+					var textArea = document.createElement("textarea");
+					textArea.value = email;
+					textArea.style.position = "absolute";
+					textArea.style.left = "-9999px";
+					textArea.style.top = "-9999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+
+					try {
+						var successful = document.execCommand('copy');
+						if (successful) {
+							copySuccess();
+						}
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +394,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailCopy();
 	});
 
 


### PR DESCRIPTION
💡 **What:** Added a "Copy" button next to the obfuscated email address in the contact section. This button de-obfuscates the email string on the client-side (replacing 'DOT', 'AT', and spaces) and copies it cleanly to the user's clipboard. It gives immediate visual feedback by turning into a checkmark.
🎯 **Why:** Obfuscating an email is great for avoiding spam bots, but it creates immense friction for real users who just want to send an email without manually re-typing or correcting copied strings.
📸 **Before/After:** Before, users had to copy "sofia DOT dutta 17 AT gmail DOT com" and manually fix it in their email client. After, they click the copy icon, see a checkmark, and get "sofia.dutta17@gmail.com" in their clipboard.
♿ **Accessibility:** Added `aria-label` and `title` attributes ("Copy email address", "Copied!") so screen reader and mouse users are fully aware of what the button does.

*(Note: minor copyright text formatting fix included to satisfy `verify_changes.py` regression tests)*

---
*PR created automatically by Jules for task [3669411889592719407](https://jules.google.com/task/3669411889592719407) started by @sofiadutta*