### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attributes to third-party iframes

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-23 - Iframe Sandbox Restrictions
+**Vulnerability:** Missing sandbox restrictions on third-party iframes (YouTube).
+**Learning:** Iframes without a sandbox attribute can execute scripts, navigate the top-level window, or submit forms, posing a significant risk if the third-party content is compromised.
+**Prevention:** Always apply a restrictive `sandbox` attribute (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) when embedding third-party iframes to enforce defense-in-depth.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Missing sandbox restrictions on third-party YouTube iframes. Iframes without a `sandbox` attribute have broad permissions to execute scripts, navigate the top-level window, submit forms, or trigger unauthorized downloads. 
**Impact:** If the embedded third-party content is ever compromised or serves malicious ads, it could result in an XSS breakout, unauthorized top-level redirection (phishing), or other client-side attacks against visitors viewing the portfolio.
**Fix:** Added the `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attribute to both YouTube iframes in `index.html`. This enforces a restrictive boundary, acting as a defense-in-depth measure while preserving standard playback and fullscreen functionalities.
**Verification:** Run `git diff` to ensure the attributes are added correctly, and use Playwright or view the `index.html` file to verify the embeds render normally.

---
*PR created automatically by Jules for task [6003514288800094828](https://jules.google.com/task/6003514288800094828) started by @sofiadutta*