### PR TITLE
🎨 Palette: Add copy to clipboard for email address

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Obfuscated Email Copy UX]
+**Learning:** When adding a 'copy to clipboard' feature for obfuscated text (like emails), do not store the real text in `data-*` attributes, as it defeats the purpose of obfuscation. Also, using `.html()` or similar with `data-original-text` attributes to store the original button HTML can introduce XSS risks (flagged by CodeQL).
+**Action:** Extract the obfuscated text directly from the DOM, de-obfuscate it dynamically inside the event handler, and use hardcoded safe HTML strings for button state transitions.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,13 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										&nbsp;
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,62 @@
 		}
 	};
 
+
+	var copyEmailToClipboard = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var obfuscatedEmailElement = document.getElementById('obfuscated-email');
+
+		if (copyBtn && obfuscatedEmailElement) {
+			copyBtn.addEventListener('click', function(e) {
+				e.preventDefault();
+
+				var obfuscatedText = obfuscatedEmailElement.innerText || obfuscatedEmailElement.textContent;
+				var realEmail = obfuscatedText.replace(/DOT/g, '.').replace(/AT/g, '@').replace(/\s/g, '');
+
+				var copyToClipboard = function(text) {
+					if (navigator.clipboard && window.isSecureContext) {
+						return navigator.clipboard.writeText(text);
+					} else {
+						var textArea = document.createElement("textarea");
+						textArea.value = text;
+						textArea.style.position = "absolute";
+						textArea.style.left = "-9999px";
+						textArea.style.top = "-9999px";
+						document.body.appendChild(textArea);
+						textArea.focus();
+						textArea.select();
+						try {
+							document.execCommand('copy');
+							textArea.remove();
+							return Promise.resolve();
+						} catch (err) {
+							textArea.remove();
+							return Promise.reject(err);
+						}
+					}
+				};
+
+				copyBtn.disabled = true;
+				var originalHtml = '<i class="icon-clipboard" aria-hidden="true"></i> Copy';
+
+				copyToClipboard(realEmail).then(function() {
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHtml;
+						copyBtn.disabled = false;
+					}, 2000);
+				}).catch(function(err) {
+					console.error('Failed to copy: ', err);
+					copyBtn.innerHTML = 'Failed';
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHtml;
+						copyBtn.disabled = false;
+					}, 2000);
+				});
+			});
+		}
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +395,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a copy-to-clipboard button for the obfuscated email address.

🎯 Why: To improve user experience by allowing users to easily copy the email address instead of manually selecting, copying, and fixing it.

📸 Before/After: NA (UI change is just adding a button)

♿ Accessibility: Added `aria-label` and `title` to the new button for screen readers and tooltips.

---
*PR created automatically by Jules for task [16748975277547227748](https://jules.google.com/task/16748975277547227748) started by @sofiadutta*