### PR TITLE
🛡️ Sentinel: [security improvement] Add sandbox to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2026-03-29 - Restrictive Sandbox on Third-Party Iframes
+**Vulnerability:** Missing sandbox attributes on iframe elements loading third-party content.
+**Learning:** Third-party embeds should never be fully trusted. A defense-in-depth approach is required to limit capabilities of iframe content.
+**Prevention:** Always use restrictive sandbox attributes (allow-scripts allow-same-origin allow-presentation allow-popups) on iframe tags to prevent XSS breakouts and unauthorized actions.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" allowfullscreen title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" allowfullscreen title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing sandbox attributes on iframe elements loading third-party content (YouTube embeds).
🎯 Impact: Without sandboxing, embedded third-party content has unrestricted capabilities, potentially allowing XSS breakouts, unauthorized top-level navigation, or triggering popups without user consent if the third-party domain is compromised.
🔧 Fix: Added restrictive `sandbox` attributes (`allow-scripts allow-same-origin allow-presentation allow-popups`) to the two YouTube `iframe` tags in `index.html`. This enforces a defense-in-depth approach, explicitly allowing only necessary features for YouTube to function correctly while blocking other potentially malicious actions. Also added a journal entry to `.jules/sentinel.md` documenting the learning.
✅ Verification: Tested visual and functional behavior locally. Ran relevant regression scripts (`verify_changes.py`, `verify_resize.py`) which passed successfully. Verified that the journal was successfully appended.

---
*PR created automatically by Jules for task [2786221691895182063](https://jules.google.com/task/2786221691895182063) started by @sofiadutta*