### PR TITLE
🎨 Palette: [UX improvement] Add copy to clipboard for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-24 - [Anti-Spam Email Friction]
+**Learning:** Obfuscated email addresses prevent spam but create significant friction for users who have to manually reformat the text.
+**Action:** Add a copy button that de-obfuscates the email client-side, preserving anti-spam benefits while resolving the UX issue.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm pull-right" aria-label="Copy Email Address" title="Copy Email Address">Copy</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,46 @@
 		}
 	};
 
+	var copyEmailToClipboard = function() {
+		$('#copy-email-btn').on('click', function() {
+			var btn = $(this);
+			var originalText = 'Copy';
+
+			// Get obfuscated text and clean it up
+			var emailText = $('#obfuscated-email').text();
+			emailText = emailText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s/g, '');
+
+			var showSuccess = function() {
+				btn.text('Copied!');
+				btn.prop('disabled', true);
+				setTimeout(function() {
+					btn.text(originalText);
+					btn.prop('disabled', false);
+				}, 2000);
+			};
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(emailText).then(showSuccess);
+			} else {
+				// Fallback
+				var textarea = document.createElement('textarea');
+				textarea.value = emailText;
+				textarea.style.position = 'absolute';
+				textarea.style.left = '-9999px';
+				textarea.style.top = '-9999px';
+				document.body.appendChild(textarea);
+				textarea.select();
+				try {
+					document.execCommand('copy');
+					showSuccess();
+				} catch (err) {
+					console.error('Fallback: Oops, unable to copy', err);
+				}
+				document.body.removeChild(textarea);
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +379,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a "Copy" button next to the obfuscated email address that de-obfuscates the string client-side and copies it to the user's clipboard. Also includes a temporary "Copied!" visual feedback state.
🎯 Why: Obfuscated email addresses (like "sofia DOT dutta 17 AT gmail DOT com") successfully prevent spam bots from scraping, but they create significant friction for human users who have to manually retype or reformat the string. This preserves the anti-spam benefits while resolving the UX issue.
📸 Before/After: See PR attachments.
♿ Accessibility: The button uses the existing `btn` classes for proper focus states, and includes `aria-label` and `title` attributes for screen readers and sighted users respectively.

---
*PR created automatically by Jules for task [14613800061681082506](https://jules.google.com/task/14613800061681082506) started by @sofiadutta*