### PR TITLE
🎨 Palette: [UX improvement] Add copy button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [De-obfuscating Anti-Spam Emails Client-Side for UX]
+**Learning:** Obfuscated email addresses (like `name DOT last AT domain DOT com`) stop bots but create terrible UX for legitimate users who must manually retype them. Wrapping them in a "Copy" button that dynamically de-obfuscates (via regex replacements for text and whitespace) inside the click event listener allows us to maintain spam protection while providing a one-click native clipboard experience.
+**Action:** When encountering obfuscated text, do not put the raw string in `data-*` attributes. Read it from the DOM dynamically upon interaction, clean it up, and copy it to the user's clipboard while providing visual confirmation (like "Copied!").

--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm pull-right" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard3" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,49 @@
 		}
 	};
 
+	var copyEmailToClipboard = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				var rawText = emailSpan.textContent || emailSpan.innerText;
+				var email = rawText.replace(/DOT/g, '.').replace(/AT/g, '@').replace(/\s/g, '');
+
+				var onSuccess = function() {
+					copyBtn.disabled = true;
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+					setTimeout(function() {
+						copyBtn.innerHTML = '<i class="icon-clipboard3" aria-hidden="true"></i> Copy';
+						copyBtn.disabled = false;
+					}, 2000);
+				};
+
+				if (navigator.clipboard && navigator.clipboard.writeText) {
+					navigator.clipboard.writeText(email).then(onSuccess).catch(function(err) {
+						console.error('Failed to copy: ', err);
+					});
+				} else {
+					var textArea = document.createElement("textarea");
+					textArea.value = email;
+					textArea.style.position = "absolute";
+					textArea.style.left = "-9999px";
+					textArea.style.top = "-9999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						onSuccess();
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +382,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
💡 **What:** Added a "Copy" button next to the obfuscated email address in the Contact section that dynamically de-obfuscates the email and copies it to the user's clipboard, displaying a temporary "Copied!" state.
🎯 **Why:** Obfuscated emails (like `name DOT last AT domain DOT com`) are great for deterring spam bots but create a terrible UX for legitimate users who must manually retype the address. This change maintains spam protection while providing a modern, one-click copy experience.
📸 **Before/After:** The plain text email now features a Bootstrap `btn-primary` alongside it.
♿ **Accessibility:** The new button is keyboard focusable, includes an `aria-label="Copy email address"` for screen readers, and a `title="Copy email address"` for sighted mouse users. Icons are marked with `aria-hidden="true"`.

---
*PR created automatically by Jules for task [11651699709706618747](https://jules.google.com/task/11651699709706618747) started by @sofiadutta*