### PR TITLE
⚡ Bolt: Throttle scroll events with requestAnimationFrame

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -149,14 +149,22 @@
 	    }
 		});
 
-		$(window).scroll(function(){
-			if ( $('body').hasClass('offcanvas') ) {
-
-    			$('body').removeClass('offcanvas');
-    			$('.js-colorlib-nav-toggle').removeClass('active');
-			
-	    	}
-		});
+		// Optimization: Use native event listener and requestAnimationFrame to throttle scroll events,
+		// preventing main thread blocking and layout thrashing during scrolling.
+		var isScrolling = false;
+		window.addEventListener('scroll', function() {
+			if (!isScrolling) {
+				window.requestAnimationFrame(function() {
+					if (document.body.classList.contains('offcanvas')) {
+						document.body.classList.remove('offcanvas');
+						var toggle = document.querySelector('.js-colorlib-nav-toggle');
+						if (toggle) toggle.classList.remove('active');
+					}
+					isScrolling = false;
+				});
+				isScrolling = true;
+			}
+		}, { passive: true });
 
 	};
 


### PR DESCRIPTION
💡 What: Replaced the unthrottled jQuery `$(window).scroll` listener in `js/main.js` with a native `window.addEventListener` that utilizes `requestAnimationFrame` for throttling.
🎯 Why: Unthrottled scroll listeners trigger hundreds of times per second during user scrolling, which causes main thread blocking, layout thrashing, and degraded scrolling performance (jank).
📊 Impact: Reduces the frequency of scroll event callback execution to align with the browser's render cycle (typically 60 times per second instead of potentially hundreds), significantly improving scroll smoothness and overall responsiveness.
🔬 Measurement: Verified the scroll listener behavior using Playwright to ensure the offcanvas menu still closes upon scrolling without causing test timeouts or regressions.

---
*PR created automatically by Jules for task [12138830653743951638](https://jules.google.com/task/12138830653743951638) started by @sofiadutta*