### PR TITLE
🛡️ Sentinel: [security improvement] Add sandbox attribute to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-02-28 - Securing Third-Party Iframes
+**Vulnerability:** Third-party iframes (e.g., YouTube embeds) lacking the `sandbox` attribute, posing a potential defense-in-depth XSS breakout risk.
+**Learning:** Including third-party content without sandboxing gives the embedded content too many privileges by default. Restricting it with a `sandbox` attribute mitigates these risks.
+**Prevention:** Always include restrictive `sandbox` attributes (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) when embedding third-party `iframe` elements.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Third-party iframes (YouTube embeds) lack `sandbox` attributes, posing a defense-in-depth risk for XSS breakouts.
🎯 Impact: If the third-party provider is compromised, malicious scripts could potentially interact with the parent window or access its context. Sandboxing restricts these capabilities.
🔧 Fix: Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to all third-party `iframe` elements.
✅ Verification: Verified visually and through the automated test suite (`verify_changes.py` and `verify_resize.py`).

---
*PR created automatically by Jules for task [6336116441364473006](https://jules.google.com/task/6336116441364473006) started by @sofiadutta*