### PR TITLE
🛡️ Sentinel: [security improvement] Add sandbox attribute to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2024-05-23 - Third-Party Iframe Sandbox
+**Vulnerability:** Missing sandbox attribute on third-party iframes (e.g., YouTube embeds) allowing unrestricted execution context.
+**Learning:** Third-party content could be compromised to execute XSS or breakout attacks against the parent context without defense-in-depth restrictions.
+**Prevention:** Always apply the `sandbox` attribute with least-privilege permissions (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) when embedding third-party iframes.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,8 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<!-- Security: Added sandbox attribute to prevent potential XSS breakout from third-party iframe -->
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +827,8 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<!-- Security: Added sandbox attribute to prevent potential XSS breakout from third-party iframe -->
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
## 🚨 Severity
MEDIUM

## 💡 Vulnerability
Missing sandbox attribute on third-party iframes (YouTube embeds) allows an unrestricted execution context.

## 🎯 Impact
Without sandbox restrictions, if the third-party iframe content is compromised, it could potentially execute XSS or breakout attacks against the top-level parent context.

## 🔧 Fix
Added restrictive `sandbox` attributes (`allow-scripts allow-same-origin allow-presentation allow-popups`) and explanatory security comments to the iframe elements as a defense-in-depth measure.

## ✅ Verification
Ran existing tests and verified no regressions.

---
*PR created automatically by Jules for task [11971078513615102165](https://jules.google.com/task/11971078513615102165) started by @sofiadutta*