### PR TITLE
🎨 Palette: Add copy button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-23 - [Obfuscated Email Copy Experience]
+**Learning:** Obfuscated email addresses (e.g., `user DOT name AT domain DOT com`) are great for anti-spam, but terrible for user experience as they force manual copying and editing. However, we cannot store the de-obfuscated string in HTML attributes (like `data-email`) because scrapers would easily find it.
+**Action:** When improving obfuscated email UX, add a "Copy Email" button that reads the obfuscated text from the DOM and de-obfuscates it dynamically via client-side JavaScript within the event listener before writing to the clipboard. Use modern `navigator.clipboard` with a fallback, and temporarily disable the button to provide visual feedback ("Copied!") without allowing rapid clicks to overwrite stored state.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,8 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address to clipboard"><i class="icon-clipboard"></i> Copy Email</button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,51 @@
 		}
 	};
 
+
+	var copyEmailToClipboard = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailEl = document.getElementById('obfuscated-email');
+
+		if (copyBtn && emailEl) {
+			copyBtn.addEventListener('click', function(e) {
+				e.preventDefault();
+
+				var rawText = emailEl.textContent || emailEl.innerText;
+				var cleanEmail = rawText.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var originalHTML = copyBtn.innerHTML;
+				copyBtn.disabled = true;
+				copyBtn.innerHTML = '<i class="icon-check"></i> Copied!';
+
+				setTimeout(function() {
+					copyBtn.innerHTML = originalHTML;
+					copyBtn.disabled = false;
+				}, 2000);
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(cleanEmail).catch(function(err) {
+						console.error('Could not copy text: ', err);
+					});
+				} else {
+					var textArea = document.createElement("textarea");
+					textArea.value = cleanEmail;
+					textArea.style.position = "absolute";
+					textArea.style.left = "-9999px";
+					textArea.style.top = "-9999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +384,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
- 💡 **What**: Added a "Copy Email" button next to the obfuscated contact email. The button dynamically de-obfuscates the text when clicked and copies it to the clipboard, providing visual feedback ("Copied!").
- 🎯 **Why**: Obfuscated emails (e.g., `user DOT name AT domain DOT com`) protect against spam bots but create friction for real users who have to manually copy and correct the text. This improves UX by making it a single click, without exposing the raw email in the HTML source.
- 📸 **Before/After**: Added a small button below the email text that changes to "Copied!" temporarily on click.
- ♿ **Accessibility**: The button uses a semantic `<button>` tag, has an `aria-label="Copy email address to clipboard"`, and supports keyboard navigation.

---
*PR created automatically by Jules for task [13680133284035637177](https://jules.google.com/task/13680133284035637177) started by @sofiadutta*