### PR TITLE
🛡️ Sentinel: [security improvement] Add sandbox attributes to YouTube embeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2025-02-19 - Sandbox Third-Party Iframes
+**Vulnerability:** Embedded third-party content (like YouTube iframes) missing `sandbox` attributes.
+**Learning:** Third-party iframes pose a potential security risk (XSS breakout, malicious scripts) if the third party is compromised. The strict CSP handles `script-src` but doesn't inherently sandbox iframe content contexts.
+**Prevention:** Always apply the `sandbox` attribute with restricted permissions (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) to `iframe` elements loading external origins to enforce defense-in-depth.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: LOW (Defense in Depth)

💡 Vulnerability: Embedded third-party content (YouTube iframes) without `sandbox` attributes can potentially execute malicious scripts or break out of the iframe if the third-party is compromised.

🎯 Impact: Limits the potential impact of an XSS vulnerability in the embedded third-party content by enforcing strict sandbox restrictions.

🔧 Fix: Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to all YouTube `iframe` elements.

✅ Verification: Verified HTML syntax and ran existing regression tests.

---
*PR created automatically by Jules for task [2939173325998708348](https://jules.google.com/task/2939173325998708348) started by @sofiadutta*