### PR TITLE
🎨 Palette: Add copy to clipboard for email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-24 - [Anti-Spam Email Client-Side De-obfuscation]
+**Learning:** When adding a "Copy to Clipboard" feature for an obfuscated email address (e.g., "name DOT last AT email DOT com"), storing the de-obfuscated email in a `data-*` attribute defeats the purpose of the anti-spam protection, as scrapers can easily read it.
+**Action:** Always read the obfuscated text directly from the DOM and de-obfuscate it dynamically client-side within the click event listener using global regex replacements.

--- a/index.html
+++ b/index.html
@@ -860,8 +860,12 @@
 								<div class="colorlib-icon">
 									<i class="icon-mail6"></i>
 								</div>
-								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+								<div class="colorlib-text" style="display: flex; align-items: center; gap: 10px;">
+									<p id="contact-email" style="margin: 0;">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="padding: 2px 8px; font-size: 14px; display: inline-flex; align-items: center; justify-content: center;">
+										<i class="icon-clipboard" aria-hidden="true" style="margin: 0;"></i>
+										<span id="copy-email-text" style="margin-left: 5px; font-size: 12px; font-weight: normal; text-transform: none;">Copy</span>
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,58 @@
 		}
 	};
 
+	var copyEmailToClipboard = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var textSpan = document.getElementById('copy-email-text');
+		var emailEl = document.getElementById('contact-email');
+
+		if (!btn || !textSpan || !emailEl) return;
+
+		btn.addEventListener('click', function() {
+			var obfuscatedEmail = emailEl.innerText || emailEl.textContent;
+			var email = obfuscatedEmail.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s/g, '');
+
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(email).then(showCopiedFeedback, fallbackCopyTextToClipboard.bind(null, email));
+			} else {
+				fallbackCopyTextToClipboard(email);
+			}
+		});
+
+		function showCopiedFeedback() {
+			btn.disabled = true;
+			var originalText = textSpan.innerText;
+			textSpan.innerText = "Copied!";
+			setTimeout(function() {
+				textSpan.innerText = originalText;
+				btn.disabled = false;
+			}, 2000);
+		}
+
+		function fallbackCopyTextToClipboard(text) {
+			var textArea = document.createElement("textarea");
+			textArea.value = text;
+
+			// Avoid scrolling to bottom
+			textArea.style.top = "-9999px";
+			textArea.style.left = "-9999px";
+			textArea.style.position = "absolute";
+
+			document.body.appendChild(textArea);
+			textArea.focus();
+			textArea.select();
+
+			try {
+				document.execCommand('copy');
+				showCopiedFeedback();
+			} catch (err) {
+				console.error('Fallback: Oops, unable to copy', err);
+			}
+
+			document.body.removeChild(textArea);
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +391,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailToClipboard();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a "Copy" button next to the contact email address that de-obfuscates the email and copies it to the clipboard.
🎯 Why: The obfuscated email ("sofia DOT dutta 17 AT gmail DOT com") provides good anti-spam protection but requires the user to manually type it out, leading to friction. This provides a 1-click solution while preserving anti-spam.
📸 Before/After: Visual feedback "Copied!" is shown temporarily on button click.
♿ Accessibility: Button includes `aria-label="Copy email address"` and `title="Copy email address"` for screen readers and tooltips.

---
*PR created automatically by Jules for task [10408831380899230997](https://jules.google.com/task/10408831380899230997) started by @sofiadutta*