### PR TITLE
🎨 Palette: Add copy to clipboard functionality for contact email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-23 - [De-obfuscating Email via Copy Button]
+**Learning:** For obfuscated data (like anti-spam emails), we cannot store the de-obfuscated string in HTML attributes (e.g., `data-*`). The most effective approach is to read the obfuscated text directly from the DOM and dynamically de-obfuscate it client-side within the event listener to preserve anti-spam protection while providing a seamless UX for legitimate users via a copy button.
+**Action:** When creating interactions around obfuscated data, perform transformations client-side on interaction rather than exposing the real data in the DOM. Ensure clipboard interactions have appropriate secure context fallbacks.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span> <button id="copy-email-btn" class="btn btn-primary btn-xs" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard"></i></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,46 @@
 		}
 	};
 
+	var copyEmailAction = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('contact-email');
+		if (btn && emailSpan) {
+			btn.addEventListener('click', function() {
+				var obfuscated = emailSpan.innerText || emailSpan.textContent;
+				var realEmail = obfuscated.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(realEmail).then(function() {
+						showCopiedFeedback(btn);
+					});
+				} else {
+					// Fallback
+					var textArea = document.createElement("textarea");
+					textArea.value = realEmail;
+					document.body.appendChild(textArea);
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						showCopiedFeedback(btn);
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
+	var showCopiedFeedback = function(btn) {
+		var originalHTML = btn.innerHTML;
+		btn.disabled = true;
+		btn.innerHTML = 'Copied!';
+		setTimeout(function() {
+			btn.innerHTML = originalHTML;
+			btn.disabled = false;
+		}, 2000);
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +379,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		copyEmailAction();
 	});
 
 


### PR DESCRIPTION
### 💡 What
Added a "Copy to Clipboard" button next to the obfuscated contact email address in the contact section.

### 🎯 Why
The email address is currently obfuscated (e.g., `sofia DOT dutta 17 AT gmail DOT com`) to deter spam bots. While effective, this creates a poor user experience as users must manually retype and fix the address. The new button de-obfuscates the email client-side and copies the valid email directly to the user's clipboard, bridging the gap between anti-spam measures and good UX.

### 📸 Before/After
*   **Before:** Plain text obfuscated email requiring manual typing.
*   **After:** Obfuscated email displayed alongside a small clipboard icon button that provides "Copied!" feedback and copies the real email address.

### ♿ Accessibility
*   The button includes an `aria-label="Copy email address"` and a matching `title` attribute so screen readers and mouse users understand its purpose.
*   Focus state styling is inherited from the existing `.btn` class.
*   The button is temporarily disabled during the "Copied!" feedback state to prevent rapid sequential clicks from breaking the interaction flow or overwriting the original HTML variable with the "Copied!" text.

---
*PR created automatically by Jules for task [8957686858965789832](https://jules.google.com/task/8957686858965789832) started by @sofiadutta*