### PR TITLE
⚡ Bolt: Throttle offcanvas scroll listener

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-01-08 - LCP Optimization for Background Images
 **Learning:** Background images defined in CSS (or inline styles) are often discovered late by the browser. Preloading them via `<link rel="preload">` significantly aids LCP.
 **Action:** Always check for critical background images in Hero sections and add preloads for them, especially when image optimization tools are unavailable to reduce their size.
+## 2025-01-09 - Unthrottled jQuery Scroll Listeners
+**Learning:** The codebase relies on unthrottled jQuery scroll event listeners (e.g., `$(window).scroll(...)`) which cause layout thrashing and block the main thread by executing on every scroll pixel.
+**Action:** Replace unthrottled jQuery scroll listeners with native `window.addEventListener('scroll', ...)` and throttle DOM updates using `requestAnimationFrame` with a boolean lock for optimal main thread performance.

--- a/js/main.js
+++ b/js/main.js
@@ -149,13 +149,23 @@
 	    }
 		});
 
-		$(window).scroll(function(){
-			if ( $('body').hasClass('offcanvas') ) {
-
-    			$('body').removeClass('offcanvas');
-    			$('.js-colorlib-nav-toggle').removeClass('active');
-			
-	    	}
+		// Optimization: Throttle DOM updates on scroll using native events and requestAnimationFrame
+		// to avoid layout thrashing and main thread blocking common with unthrottled jQuery scroll listeners.
+		var isScrolling = false;
+		window.addEventListener('scroll', function(){
+			if (!isScrolling) {
+				window.requestAnimationFrame(function() {
+					if ( document.body.classList.contains('offcanvas') ) {
+						document.body.classList.remove('offcanvas');
+						var toggles = document.querySelectorAll('.js-colorlib-nav-toggle');
+						for (var i = 0; i < toggles.length; i++) {
+							toggles[i].classList.remove('active');
+						}
+					}
+					isScrolling = false;
+				});
+				isScrolling = true;
+			}
 		});
 
 	};


### PR DESCRIPTION
💡 What: Replaced the unthrottled `$(window).scroll` jQuery event listener for the offcanvas menu with a native `window.addEventListener` implementation, throttled via `requestAnimationFrame` and a boolean lock, including inline explanatory comments.
🎯 Why: Unthrottled scroll listeners cause excessive layout thrashing and block the main thread on every scroll pixel, severely degrading scroll performance.
📊 Impact: Reduces scroll event handling execution time drastically, preventing main thread blocking and ensuring a smooth 60fps scrolling experience.
🔬 Measurement: Verified the offcanvas menu behavior on scroll using automated Playwright tests triggering native scroll events.

---
*PR created automatically by Jules for task [11617485541779881346](https://jules.google.com/task/11617485541779881346) started by @sofiadutta*