### PR TITLE
🎨 Palette: Add copy button to obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Interacting with Obfuscated Strings]
+**Learning:** For anti-spam emails displayed as "name DOT last AT domain DOT com", adding interactive features (like a copy button) risks exposing the cleartext email if stored in HTML data attributes.
+**Action:** When adding interactions to obfuscated data, never store the de-obfuscated string in the DOM. Always read the obfuscated text and dynamically de-obfuscate it client-side within the event listener to preserve protection.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span> <button id="copy-email-btn" class="btn btn-primary btn-xs" aria-label="Copy email address" title="Copy email address" style="margin-left: 10px;"><i class="icon-clipboard" aria-hidden="true"></i> Copy</button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,43 @@
 		}
 	};
 
+	var setupEmailCopy = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('contact-email');
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				var obfuscated = emailSpan.textContent || emailSpan.innerText;
+				var email = obfuscated.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var successCallback = function() {
+					var originalHtml = copyBtn.innerHTML;
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHtml;
+					}, 2000);
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(email).then(successCallback);
+				} else {
+					var textArea = document.createElement("textarea");
+					textArea.value = email;
+					textArea.style.position = "fixed";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						successCallback();
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +376,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		setupEmailCopy();
 	});
 
 

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,1 @@
+sed -i 's|<p>sofia DOT dutta 17 AT gmail DOT com</p>|<p><span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span> <button id="copy-email-btn" class="btn btn-primary btn-xs" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard" aria-hidden="true"></i> Copy</button></p>|' index.html

--- a/test_playwright.py
+++ b/test_playwright.py
@@ -1,0 +1,75 @@
+import asyncio
+from playwright.async_api import async_playwright
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        context = await browser.new_context(permissions=['clipboard-read', 'clipboard-write'])
+        page = await context.new_page()
+        file_url = f"file://{os.getcwd()}/index.html"
+        await page.goto(file_url)
+
+        # Let's write the JS to js/main.js
+        with open('js/main.js', 'a') as f:
+            f.write("""
+    // Copy email to clipboard
+    var setupEmailCopy = function() {
+        var copyBtn = document.getElementById('copy-email-btn');
+        var emailSpan = document.getElementById('contact-email');
+        if (copyBtn && emailSpan) {
+            copyBtn.addEventListener('click', function() {
+                var obfuscated = emailSpan.textContent || emailSpan.innerText;
+                var email = obfuscated.replace(/\\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+                if (navigator.clipboard && window.isSecureContext) {
+                    navigator.clipboard.writeText(email).then(function() {
+                        var originalHtml = copyBtn.innerHTML;
+                        copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+                        setTimeout(function() {
+                            copyBtn.innerHTML = originalHtml;
+                        }, 2000);
+                    });
+                } else {
+                    // Fallback
+                    var textArea = document.createElement("textarea");
+                    textArea.value = email;
+                    textArea.style.position = "fixed";  // avoid scrolling to bottom
+                    document.body.appendChild(textArea);
+                    textArea.focus();
+                    textArea.select();
+                    try {
+                        document.execCommand('copy');
+                        var originalHtml = copyBtn.innerHTML;
+                        copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+                        setTimeout(function() {
+                            copyBtn.innerHTML = originalHtml;
+                        }, 2000);
+                    } catch (err) {
+                        console.error('Fallback: Oops, unable to copy', err);
+                    }
+                    document.body.removeChild(textArea);
+                }
+            });
+        }
+    };
+    $(function(){
+        setupEmailCopy();
+    });
+            """)
+
+        await page.reload()
+
+        # Test copy button
+        await page.locator('#copy-email-btn').click()
+
+        # Check if text changes
+        text = await page.locator('#copy-email-btn').inner_text()
+        print(f"Button text after click: {text}")
+
+        # Check clipboard content via fallback/secure context logic
+        # Actually in playwright file:// is not secure context by default?
+
+        await browser.close()
+
+asyncio.run(main())


### PR DESCRIPTION
### 💡 What
Added a "Copy" button next to the obfuscated contact email address that correctly de-obfuscates the text and copies the actual email to the user's clipboard, providing visual feedback ("Copied!").

### 🎯 Why
The contact email is obfuscated (e.g., "sofia DOT dutta..."). Asking users to manually select, copy, and fix the format creates friction. Providing a one-click copy button improves the UX while maintaining the anti-spam obfuscation in the HTML source.

### 📸 Before/After
**Before:** `sofia DOT dutta 17 AT gmail DOT com` (plain text)
**After:** `sofia DOT dutta 17 AT gmail DOT com` [Copy button] (Copies `sofia.dutta17@gmail.com`)

### ♿ Accessibility
- The copy button includes an `aria-label` and `title` attribute for screen readers and sighted users hovering the icon.
- The button is keyboard navigable and uses semantic HTML elements.
- Provides clear visual confirmation when the action is successful.

---
*PR created automatically by Jules for task [13138592308380212770](https://jules.google.com/task/13138592308380212770) started by @sofiadutta*