### PR TITLE
🎨 Palette: Add copy button to obfuscated contact email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Secure Context Check for Clipboard API]
+**Learning:** When using modern APIs like `navigator.clipboard.writeText`, it requires a secure context (HTTPS) to work. It will fail silently or throw errors when testing locally via `file://` protocol or in environments without HTTPS, which is especially problematic for verification scripts like Playwright.
+**Action:** Always wrap `navigator.clipboard` calls in `if (navigator.clipboard && window.isSecureContext)` and provide a legacy `document.execCommand('copy')` fallback using a hidden textarea to ensure it works in all environments, including local testing.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-default btn-sm" aria-label="Copy email address to clipboard" title="Copy email address" style="margin-left: 10px; padding: 2px 8px;">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,51 @@
 		}
 	};
 
+	var initEmailCopy = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+
+		if (btn && emailSpan) {
+			btn.addEventListener('click', function() {
+				var obfuscatedText = emailSpan.textContent || emailSpan.innerText;
+				var deobfuscated = obfuscatedText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s/g, '');
+
+				var copySuccess = function() {
+					var icon = btn.querySelector('i');
+					if (icon) {
+						icon.className = 'icon-check';
+						setTimeout(function() {
+							icon.className = 'icon-clipboard';
+						}, 2000);
+					}
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).then(copySuccess).catch(function(err) {
+						console.error('Could not copy text: ', err);
+					});
+				} else {
+					// Fallback
+					var textArea = document.createElement("textarea");
+					textArea.value = deobfuscated;
+					textArea.style.position = "fixed";
+					textArea.style.left = "-999999px";
+					textArea.style.top = "-999999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						copySuccess();
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +384,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initEmailCopy();
 	});
 
 


### PR DESCRIPTION
**💡 What**
Added a "Copy to Clipboard" button next to the obfuscated email address (`sofia DOT dutta ...`) in the contact section, allowing users to automatically de-obfuscate and copy the email.

**🎯 Why**
Previously, users had to manually parse and copy the obfuscated email address, which is frustrating and prone to errors. This enhancement reduces manual effort and improves the intuitiveness of the contact action while preserving anti-spam protections.

**📸 Before/After**
*Before:* Plain text obfuscated email.
*After:* Text alongside an interactive button with a clipboard icon.

**♿ Accessibility**
The new button includes an explicit `aria-label="Copy email address"` and a `title="Copy to clipboard"` to ensure it is fully accessible to screen readers and keyboard users. Added clear visual feedback on click.

---
*PR created automatically by Jules for task [4373153161934009752](https://jules.google.com/task/4373153161934009752) started by @sofiadutta*