### PR TITLE
🎨 Palette: Add copy button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [De-obfuscating Anti-Spam Data Client-Side]
+**Learning:** Storing de-obfuscated anti-spam data (like emails) in HTML attributes (e.g., `data-email`) exposes it to basic scrapers, defeating the purpose of obfuscation. Additionally, `navigator.clipboard.writeText` requires a secure context (`https://` or `localhost`), making fallback methods (`document.execCommand('copy')`) necessary for local development (`file://` protocols) and older browsers.
+**Action:** Always read the obfuscated string directly from the DOM and de-obfuscate it dynamically inside the event listener. Implement both `navigator.clipboard` and a fallback copy mechanism, checking `window.isSecureContext` to prevent errors.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email" style="display:inline-block; margin-right: 10px; margin-bottom: 0;">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="padding: 2px 8px;">
+										<i class="icon-clipboard" aria-hidden="true"></i>
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,61 @@
 		}
 	};
 
+	var initCopyEmail = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailEl = document.getElementById('obfuscated-email');
+		if (btn && emailEl) {
+			btn.addEventListener('click', function() {
+				var obfuscated = emailEl.textContent || emailEl.innerText;
+				var deobfuscated = obfuscated.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var fallbackCopyTextToClipboard = function(text) {
+					var textArea = document.createElement("textarea");
+					textArea.value = text;
+
+					textArea.style.top = "0";
+					textArea.style.left = "0";
+					textArea.style.position = "fixed";
+
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+
+					try {
+						document.execCommand('copy');
+						var icon = btn.querySelector('i');
+						if (icon) {
+							icon.className = 'icon-check';
+							setTimeout(function() {
+								icon.className = 'icon-clipboard';
+							}, 2000);
+						}
+					} catch (err) {
+						console.error('Fallback: Oops, unable to copy', err);
+					}
+
+					document.body.removeChild(textArea);
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).then(function() {
+						var icon = btn.querySelector('i');
+						if (icon) {
+							icon.className = 'icon-check';
+							setTimeout(function() {
+								icon.className = 'icon-clipboard';
+							}, 2000);
+						}
+					}).catch(function(err) {
+						console.error('Could not copy text: ', err);
+					});
+				} else {
+					fallbackCopyTextToClipboard(deobfuscated);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +394,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmail();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a copy-to-clipboard button next to the obfuscated email address.
🎯 Why: Users previously had to manually copy the obfuscated text and manually replace " DOT " and " AT " with "." and "@" respectively. This feature dynamically de-obfuscates the email string on click and places it in the user's clipboard, vastly improving the contact experience.
📸 Before/After: Visual changes add a small clipboard icon button next to the email. On click, the icon temporarily changes to a checkmark to provide visual feedback.
♿ Accessibility: Added `aria-label` and `title` to the icon-only button so screen readers and mouse users understand its purpose. Used `aria-hidden="true"` on the interior `<i>` icon element.

---
*PR created automatically by Jules for task [2344532766554956615](https://jules.google.com/task/2344532766554956615) started by @sofiadutta*