### PR TITLE
🎨 Palette: Add copy to clipboard for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Copying Obfuscated Anti-Spam Emails]
+**Learning:** Found an email address rendered as "sofia DOT dutta 17 AT gmail DOT com" to prevent bot scraping. While this stops spam, it forces users into a tedious manual transcription process. De-obfuscating it client-side with a "Copy" button preserves the spam protection while dramatically improving UX.
+**Action:** When encountering obfuscated contact info, implement a client-side copy-to-clipboard function that parses and formats the string dynamically, rather than expecting users to do it manually.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p style="display: flex; align-items: center; flex-wrap: wrap;">
+										<span id="contact-email" style="margin-right: 10px;">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" aria-label="Copy email address" title="Copy email address" class="btn btn-primary btn-sm btn-outline" style="margin: 0; padding: 2px 8px !important; text-transform: none; font-size: 11px;">
+											<i class="icon-clipboard" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,44 @@
 		}
 	};
 
+	var handleEmailCopy = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('contact-email');
+
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				var obfuscated = emailSpan.textContent || emailSpan.innerText;
+				var deobfuscated = obfuscated.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var onSuccess = function() {
+					var originalHtml = copyBtn.innerHTML;
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied';
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHtml;
+					}, 2000);
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).then(onSuccess);
+				} else {
+					var textArea = document.createElement("textarea");
+					textArea.value = deobfuscated;
+					textArea.style.position = "fixed";
+					textArea.style.left = "-999999px";
+					textArea.style.top = "-999999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						onSuccess();
+					} catch (err) {}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +377,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		handleEmailCopy();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a "Copy" button next to the anti-spam obfuscated email address that dynamically de-obfuscates the string and copies it to the user's clipboard, with visual feedback.
🎯 Why: To relieve users from having to manually type out and de-obfuscate "sofia DOT dutta 17 AT gmail DOT com", reducing friction while retaining the spam protection.
📸 Before/After: Added a small 'Copy' button inline with the email text, which changes to 'Copied' temporarily after a successful click.
♿ Accessibility: Added `aria-label` and `title` attributes ("Copy email address") to the new interactive button. The button receives keyboard focus and provides visual confirmation of the interaction.

---
*PR created automatically by Jules for task [7348919545038502584](https://jules.google.com/task/7348919545038502584) started by @sofiadutta*