### PR TITLE
🎨 Palette: Add copy button to obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Client-Side Email De-obfuscation for UX]
+**Learning:** Obfuscated email addresses (e.g., 'name DOT domain AT com') are effective against spam bots but create high friction for real users who cannot click or copy them easily. Storing the plain text in HTML attributes defeats the anti-spam purpose.
+**Action:** Implement an interactive copy button that reads the obfuscated string from the DOM, de-obfuscates it client-side within the event listener using regex, and copies it to the clipboard. Always provide a legacy `execCommand` fallback for local `file://` contexts and include proper ARIA labels and tooltips.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,50 @@
 		}
 	};
 
+	var setupEmailCopy = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+		if (btn && emailSpan) {
+			var originalHtml = btn.innerHTML;
+			btn.addEventListener('click', function() {
+				var obfuscated = emailSpan.textContent || emailSpan.innerText;
+				var deobfuscated = obfuscated.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+
+				var fallbackCopy = function(text) {
+					var textArea = document.createElement("textarea");
+					textArea.value = text;
+					textArea.style.top = "0";
+					textArea.style.left = "0";
+					textArea.style.position = "fixed";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+					} catch (err) {}
+					document.body.removeChild(textArea);
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).catch(function() {
+						fallbackCopy(deobfuscated);
+					});
+				} else {
+					fallbackCopy(deobfuscated);
+				}
+
+				btn.innerHTML = '<i class="icon-check" aria-hidden="true"></i>';
+				btn.setAttribute('aria-label', 'Email copied');
+				btn.setAttribute('title', 'Email copied');
+				setTimeout(function() {
+					btn.innerHTML = originalHtml;
+					btn.setAttribute('aria-label', 'Copy email address');
+					btn.setAttribute('title', 'Copy email address');
+				}, 2000);
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +383,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		setupEmailCopy();
 	});
 
 


### PR DESCRIPTION
💡 What: Added an icon-only copy button next to the obfuscated email address that dynamically de-obfuscates and copies the email to the clipboard on the client-side.
🎯 Why: Obfuscated data (like 'sofia DOT dutta AT gmail DOT com') is great for anti-spam but terrible for UX, as users cannot easily click or copy it.
📸 Before/After: Added a small clipboard icon button inline with the email text.
♿ Accessibility: Included an ARIA label and `title` attribute ('Copy email address') on the icon-only button for screen reader support and mouse user tooltips, and ensured keyboard accessibility natively via the `<button>` element.

---
*PR created automatically by Jules for task [16349550397065779618](https://jules.google.com/task/16349550397065779618) started by @sofiadutta*