### PR TITLE
🎨 Palette: Add copy button for contact email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-11-23 - [De-obfuscating Anti-Spam Data Client-Side]
+**Learning:** When implementing interactive copy functionality for obfuscated data (like anti-spam emails formatted as 'name AT domain DOT com'), never store the de-obfuscated string directly in HTML data attributes. Doing so defeats the purpose of anti-spam measures, as scrapers can easily read attributes.
+**Action:** Always read the obfuscated text directly from the visible DOM and dynamically de-obfuscate it within the JavaScript event listener right before writing to the clipboard.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="anti-spam-email" style="display: inline-block; margin-right: 10px; margin-bottom: 0;">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" aria-label="Copy email" title="Copy email" class="btn btn-primary btn-sm">
+										<i class="icon-clipboard" aria-hidden="true"></i>
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,47 @@
 		}
 	};
 
+	var initCopyEmailButton = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailEl = document.getElementById('anti-spam-email');
+		if (btn && emailEl) {
+			btn.addEventListener('click', function() {
+				var obfuscated = emailEl.textContent || emailEl.innerText;
+				var deobfuscated = obfuscated.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s/g, '');
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).then(function() {
+						var icon = btn.querySelector('i');
+						if (icon) {
+							icon.className = 'icon-check';
+							setTimeout(function() {
+								icon.className = 'icon-clipboard';
+							}, 2000);
+						}
+					});
+				} else {
+					var textArea = document.createElement("textarea");
+					textArea.value = deobfuscated;
+					textArea.style.position = "fixed";
+					textArea.style.left = "-999999px";
+					document.body.appendChild(textArea);
+					textArea.focus();
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						var icon = btn.querySelector('i');
+						if (icon) {
+							icon.className = 'icon-check';
+							setTimeout(function() {
+								icon.className = 'icon-clipboard';
+							}, 2000);
+						}
+					} catch (err) {}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +380,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmailButton();
 	});
 
 


### PR DESCRIPTION
### 💡 What
Added a "Copy email" button next to the obfuscated contact email address on the main page.

### 🎯 Why
The email address is obfuscated for anti-spam purposes (e.g., "sofia DOT dutta 17 AT gmail DOT com"). This makes it frustrating for legitimate users to contact the author, as they have to manually reformat the string. This button provides a 1-click solution to copy the correct email.

### 📸 Before/After
Before: Only the obfuscated text was displayed.
After: A small, accessible copy button is displayed next to the text. When clicked, it copies the properly formatted email and briefly changes to a checkmark icon to provide feedback.

### ♿ Accessibility
- Added `aria-label="Copy email"` and `title="Copy email"` to the icon-only button so screen readers and mouse users understand its purpose.
- Maintained anti-spam security by keeping the de-obfuscated email completely out of the DOM (no data attributes), computing it dynamically in JavaScript only when clicked.

---
*PR created automatically by Jules for task [13121704444215572086](https://jules.google.com/task/13121704444215572086) started by @sofiadutta*