### PR TITLE
🎨 Palette: Add copy button for contact email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Secure Clipboard Copy for Obfuscated Text]
+**Learning:** Adding a "Copy" button for obfuscated text (like anti-spam emails) creates a security/UX tradeoff. If you de-obfuscate the string in the DOM (e.g., `data-clipboard-text`), scrapers can easily harvest it. Furthermore, modern clipboard APIs (`navigator.clipboard`) silently fail in non-secure contexts (`file://` or non-HTTPS), breaking local testing and legacy environments.
+**Action:** Always read the obfuscated text directly from the DOM and de-obfuscate dynamically within the click event listener. Always provide a `document.execCommand('copy')` fallback when using the modern clipboard API to support local testing and legacy browsers.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address to clipboard" title="Copy email address to clipboard">
+										<i class="icon-clipboard" aria-hidden="true"></i> Copy Email
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,42 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				if (copyBtn.disabled) return;
+
+				var obfuscated = emailSpan.textContent || '';
+				var deobfuscated = obfuscated.replace(/DOT/g, '.').replace(/AT/g, '@').replace(/\s/g, '');
+
+				var success = function() {
+					var originalHtml = copyBtn.innerHTML;
+					copyBtn.disabled = true;
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHtml;
+						copyBtn.disabled = false;
+					}, 2000);
+				};
+
+				if (navigator.clipboard && window.isSecureContext) {
+					navigator.clipboard.writeText(deobfuscated).then(success);
+				} else {
+					var textArea = document.createElement('textarea');
+					textArea.value = deobfuscated;
+					textArea.style.position = 'fixed';
+					document.body.appendChild(textArea);
+					textArea.select();
+					try {
+						document.execCommand('copy');
+						success();
+					} catch (e) {}
+					document.body.removeChild(textArea);
+				}
+			});
+		}
 	});
 
 


### PR DESCRIPTION
## 💡 What
Added a "Copy Email" button next to the obfuscated email address in the Contact section.

## 🎯 Why
The email address is intentionally obfuscated ("sofia DOT dutta 17 AT gmail DOT com") to prevent spam bots from scraping it. However, this creates friction for genuine users who want to contact the author. The copy button de-obfuscates the email dynamically and copies the actual email address to the user's clipboard, providing a seamless micro-UX improvement.

## 📸 Before/After
**Before:** Text-only obfuscated email that users have to manually transcribe or fix after copying.
**After:** A button that handles the de-obfuscation and copying securely in one click, with visual "Copied!" feedback.

## ♿ Accessibility
- Added an `aria-label` and `title` to the icon button to ensure screen reader users and sighted mouse users understand its function.
- The button provides visual feedback when activated (text changes to "Copied!").
- The implementation falls back gracefully on non-secure contexts (`file://`).

---
*PR created automatically by Jules for task [10074816511114096113](https://jules.google.com/task/10074816511114096113) started by @sofiadutta*