### PR TITLE
🎨 Palette: Add copy to clipboard button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-04-29 - [De-obfuscating Emails Safely for UX]
+**Learning:** Obfuscating emails (e.g., "name AT domain DOT com") is a common anti-spam pattern but creates terrible UX since users cannot click or easily copy the address. If we decode the string on load and place it in the DOM (like `href="mailto:..."` or a `data` attribute), bots will scrape it.
+**Action:** To balance anti-spam with UX, implement a "Copy" button that reads the obfuscated text from the DOM, de-obfuscates it dynamically inside the click event handler (using regex to replace words and strip whitespace), copies it to the clipboard, and temporarily updates the button state. Disable the button during the "Copied!" state to prevent rapid clicks from permanently overwriting the original HTML variable.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,10 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p id="obfuscated-email" style="display: inline-block; margin-right: 10px;">sofia DOT dutta 17 AT gmail DOT com</p>
+									<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="margin-bottom: 0; padding: 4px 10px;">
+										<i class="icon-clipboard"></i> Copy
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,24 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		const copyEmailBtn = document.getElementById('copy-email-btn');
+		const obfuscatedEmail = document.getElementById('obfuscated-email');
+		if (copyEmailBtn && obfuscatedEmail) {
+			copyEmailBtn.addEventListener('click', function() {
+				const originalHTML = copyEmailBtn.innerHTML;
+				const obfuscatedText = obfuscatedEmail.textContent;
+				const cleanEmail = obfuscatedText.replace(/DOT/g, '.').replace(/AT/g, '@').replace(/\s/g, '');
+				navigator.clipboard.writeText(cleanEmail).then(() => {
+					copyEmailBtn.innerHTML = '<i class="icon-check"></i> Copied!';
+					copyEmailBtn.disabled = true;
+					setTimeout(() => {
+						copyEmailBtn.innerHTML = originalHTML;
+						copyEmailBtn.disabled = false;
+					}, 2000);
+				});
+			});
+		}
 	});
 
 


### PR DESCRIPTION
### 💡 What
Added a "Copy" button next to the obfuscated email address in the Contact section that dynamically de-obfuscates the text when clicked and copies the real email address to the user's clipboard.

### 🎯 Why
The anti-spam pattern of writing "sofia DOT dutta 17 AT gmail DOT com" protects the email from scrapers, but creates terrible UX for genuine users who must manually copy, paste, and edit the string to send an email. This change balances anti-spam protection with an intuitive one-click copy solution.

### 📸 Before/After
Before: Just the obfuscated text "sofia DOT dutta 17 AT gmail DOT com" with no interactions possible.
After: The obfuscated text is paired with an inline "Copy" button that temporarily shows "Copied!" and disables itself when clicked.

### ♿ Accessibility
- Added `aria-label` and `title` attributes ("Copy email address") to the new button for screen reader support and tooltip visibility.
- Used a native `<button>` element ensuring default keyboard focusability and enter/space activation.
- Disabled the button during the "Copied!" state to prevent rapid consecutive clicks.

---
*PR created automatically by Jules for task [13315367011896736381](https://jules.google.com/task/13315367011896736381) started by @sofiadutta*