### PR TITLE
🛡️ Sentinel: Add sandbox attributes to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+
+## 2024-05-23 - Add Sandbox Attributes to Iframes
+**Vulnerability:** Third-party iframes lacking sandbox attributes allow embedded content full access to the parent context, posing a cross-site scripting (XSS) breakout risk.
+**Learning:** Even trusted third-party embeds like YouTube require restriction via `sandbox` attributes to enforce defense-in-depth security and protect the parent page from potential compromise.
+**Prevention:** Always include restrictive `sandbox` attributes (e.g., `allow-scripts allow-same-origin allow-presentation allow-popups`) on all third-party `iframe` elements.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+													<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+													<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `sandbox` attributes on third-party YouTube iframes.
🎯 Impact: Potential for cross-site scripting (XSS) breakout or unwanted popups if the embedded content is compromised.
🔧 Fix: Added restrictive `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attributes to enforce defense-in-depth security.
✅ Verification: Verified using `git diff HEAD index.html` and running regression tests to ensure videos still display properly without errors.

---
*PR created automatically by Jules for task [5354808490792639595](https://jules.google.com/task/5354808490792639595) started by @sofiadutta*