### PR TITLE
🎨 Palette: Add copy to clipboard for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [De-obfuscating Content via Copy Interactions]
+**Learning:** Obfuscated content (like anti-spam email strings) protects against bots but degrades UX. We can bridge this gap by providing an interactive element that extracts, cleans, and copies the data client-side, isolating the text in a `<span>` to avoid pulling in adjacent button text.
+**Action:** When implementing spam-protected text that users need to utilize, provide an accessible copy button that uses Regex to clean whitespace and text-symbols before pushing to the clipboard.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span>&nbsp;
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,26 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		var copyEmailBtn = document.getElementById('copy-email-btn');
+		if (copyEmailBtn) {
+			copyEmailBtn.addEventListener('click', function() {
+				var emailSpan = document.getElementById('contact-email');
+				if (emailSpan) {
+					var rawText = emailSpan.textContent;
+					var cleanEmail = rawText.replace(/\s/g, '').replace(/DOT/g, '.').replace(/AT/g, '@');
+					navigator.clipboard.writeText(cleanEmail).then(function() {
+						var originalHTML = copyEmailBtn.innerHTML;
+						copyEmailBtn.innerHTML = 'Copied!';
+						copyEmailBtn.disabled = true;
+						setTimeout(function() {
+							copyEmailBtn.innerHTML = originalHTML;
+							copyEmailBtn.disabled = false;
+						}, 2000);
+					});
+				}
+			});
+		}
 	});
 
 


### PR DESCRIPTION
💡 What: Added an inline "Copy email" button next to the obfuscated contact email. When clicked, it automatically de-obfuscates the text and copies the clean email address to the user's clipboard, displaying a temporary "Copied!" confirmation.
🎯 Why: Obfuscated email addresses (e.g., "sofia DOT dutta AT...") prevent spam but create a poor user experience, forcing users to manually select, copy, and edit the string. This micro-interaction removes that friction completely.
📸 Before/After: Before: Plain text `sofia DOT dutta 17 AT gmail DOT com` that must be manually parsed. After: The text is wrapped in a `<span>` with an adjacent accessible icon button to automate copying.
♿ Accessibility: The new copy button is fully keyboard focusable, includes an `aria-label="Copy email address"` and a matching `title` tooltip for screen readers and mouse users.

---
*PR created automatically by Jules for task [16919985359316540119](https://jules.google.com/task/16919985359316540119) started by @sofiadutta*