### PR TITLE
🛡️ Sentinel: Add sandbox attributes to YouTube iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+## 2024-05-05 - Restrictive iframe sandbox for third-party embeds
+**Vulnerability:** Third-party YouTube iframe embeds lacked the `sandbox` attribute, granting them unrestricted permissions within the top-level browsing context.
+**Learning:** Even trusted third-party providers can present an XSS or arbitrary code execution risk if compromised. Without sandboxing, embedded frames could attempt top-level navigation.
+**Prevention:** Always add the `sandbox` attribute (e.g., `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"`) to all third-party `iframe` elements to enforce strict containment while maintaining functionality.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+													<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+													<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `sandbox` attribute on third-party `iframe` embeds (YouTube).
🎯 Impact: If the third-party content is compromised, it could attempt XSS breakouts, top-level navigation, or arbitrary code execution in the context of the parent frame.
🔧 Fix: Added the restrictive `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attribute to all third-party `iframe` elements to enforce strict containment.
✅ Verification: Verified the presence of the `sandbox` attribute in `index.html` via `git diff HEAD`.

---
*PR created automatically by Jules for task [5168192347957975882](https://jules.google.com/task/5168192347957975882) started by @sofiadutta*