### PR TITLE
🛡️ Sentinel: Add sandbox attributes to YouTube iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+## 2025-05-09 - Missing sandbox attribute on third-party iframes
+**Vulnerability:** Third-party iframes (e.g., YouTube embeds) lack sandbox attributes, creating an XSS breakout risk if the third-party domain is compromised.
+**Learning:** External content must be strictly contained to prevent it from executing malicious scripts in the parent context or redirecting the top-level window.
+**Prevention:** Always include `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` on all `iframe` tags.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🛡️ Sentinel: Add sandbox attributes to YouTube iframes

**Severity:** LOW
**Vulnerability:** Third-party iframes (YouTube embeds) lack sandbox attributes, creating a potential XSS breakout risk if the third-party domain is compromised or hijacked.
**Impact:** A compromised iframe could execute malicious scripts in the parent context or redirect the top-level window.
**Fix:** Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to all `iframe` tags. This strictly contains the embedded content, allowing it to function normally while preventing it from affecting the parent page.
**Verification:**
- Verified the `sandbox` attribute is present on both iframes via `git diff`.
- Ran the `verify_changes.py` test script.

---
*PR created automatically by Jules for task [17172322873782192196](https://jules.google.com/task/17172322873782192196) started by @sofiadutta*