### PR TITLE
🎨 Palette: Add copy button to obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-09 - Client-side Copy Functionality for Obfuscated Text
+**Learning:** When providing a 'copy' button for bot-obfuscated content (like "name DOT last AT example DOT com"), always wrap the original text in an isolatable span and use JavaScript string replacement to copy the raw email address. This provides a seamless user experience while maintaining the bot protection of the HTML. Additionally, temporarily disabling the button while it shows the "Copied!" state prevents rapid consecutive clicks from permanently overriding the original HTML state.
+**Action:** For all future "copy to clipboard" micro-interactions, decode obfuscated strings before writing to the clipboard, include proper `aria-label` attributes for icon-only buttons, and use a disabled lock for the temporary visual feedback state.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span>sofia DOT dutta 17 AT gmail DOT com</span>
+										<button class="btn btn-sm btn-default copy-btn" aria-label="Copy email address" style="margin-left: 10px; padding: 2px 6px; background: none; border: none;" title="Copy email">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,34 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		var copyBtn = document.querySelector('.copy-btn');
+		if (copyBtn) {
+			copyBtn.addEventListener('click', function() {
+				var emailSpan = this.previousElementSibling;
+				if (emailSpan) {
+					var obfuscatedText = emailSpan.textContent;
+					var decodedEmail = obfuscatedText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/\s/g, '');
+					navigator.clipboard.writeText(decodedEmail).then(function() {
+						var originalHTML = copyBtn.innerHTML;
+						var originalAria = copyBtn.getAttribute('aria-label');
+						var originalTitle = copyBtn.getAttribute('title');
+
+						copyBtn.disabled = true;
+						copyBtn.innerHTML = 'Copied!';
+						copyBtn.setAttribute('aria-label', 'Email copied');
+						copyBtn.setAttribute('title', 'Email copied');
+
+						setTimeout(function() {
+							copyBtn.disabled = false;
+							copyBtn.innerHTML = originalHTML;
+							copyBtn.setAttribute('aria-label', originalAria);
+							copyBtn.setAttribute('title', originalTitle);
+						}, 2000);
+					});
+				}
+			});
+		}
 	});
 
 


### PR DESCRIPTION
💡 **What:** Added a client-side "Copy to clipboard" button next to the obfuscated email address in the contact section. The button visually replaces the email with a decoded version directly to the clipboard and gives instant visual feedback ("COPIED!").

🎯 **Why:** To make it easier for users to contact the profile owner without having to manually type out and de-obfuscate the email address. This provides a seamless user experience while maintaining the bot protection of the original HTML.

📸 **Before/After:**
- Before: Just the raw text `sofia DOT dutta 17 AT gmail DOT com`.
- After: The text is now next to a clipboard icon button. When clicked, it copies `sofia.dutta17@gmail.com` to the clipboard and changes the button text to `COPIED!` for 2 seconds.

♿ **Accessibility:**
- The icon-only button is fully accessible to screen readers, utilizing `aria-label="Copy email address"` which changes dynamically to "Email copied".
- Includes `title` attribute for native browser tooltips for mouse users.
- The button state is `disabled=true` while displaying the "Copied!" message, ensuring keyboard users don't trigger unintended consecutive actions that would corrupt the restoration state.

---
*PR created automatically by Jules for task [10838740878614674377](https://jules.google.com/task/10838740878614674377) started by @sofiadutta*