### PR TITLE
🎨 Palette: Add copy button for email address

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2026-05-10 - Safely Coping Bot-Obfuscated Text
+**Learning:** Obfuscated contact details (like "name DOT last AT email DOT com") are tedious for users to manually clean up. Implementing a copy-to-clipboard button that uses JavaScript (`replace(/ DOT /g, ".").replace(/ AT /g, "@").replace(/ /g, "")`) to decode the string on the fly provides a delightful, zero-friction UX while preserving the bot protection in the static HTML.
+**Action:** When working with anti-scraping text obfuscation, always provide an interactive copy mechanism that seamlessly decodes the payload before writing to `navigator.clipboard`, and wrap the text target in a span for robust DOM selection.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span class="email-text">sofia DOT dutta 17 AT gmail DOT com</span> <button class="btn btn-sm btn-primary copy-email-btn" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard"></i></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,7 +339,27 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmail();
 	});
 
+	var initCopyEmail = function() {
+		var btn = document.querySelector('.copy-email-btn');
+		var textSpan = document.querySelector('.email-text');
+		if (btn && textSpan) {
+			btn.addEventListener('click', function() {
+				var originalHTML = btn.innerHTML;
+				var obfuscatedEmail = textSpan.textContent;
+				var decodedEmail = obfuscatedEmail.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+				navigator.clipboard.writeText(decodedEmail).then(function() {
+					btn.disabled = true;
+					btn.innerHTML = 'Copied!';
+					setTimeout(function() {
+						btn.disabled = false;
+						btn.innerHTML = originalHTML;
+					}, 2000);
+				});
+			});
+		}
+	};
 
 }());


### PR DESCRIPTION
**💡 What:**
Added a "Copy to clipboard" button next to the obfuscated email address in the Contact section. The button smoothly decodes the anti-bot formatting (`DOT` to `.`, `AT` to `@`, removes spaces) on the fly and writes the valid email directly to the user's clipboard. It also provides immediate visual feedback by changing the button text to "Copied!" and temporarily disabling itself.

**🎯 Why:**
Currently, users trying to contact the author have to manually highlight, copy, and then edit the obfuscated email address in their email client (replacing "DOT" and "AT" strings). This is a tedious, high-friction process. This micro-interaction removes that friction completely while still keeping the static HTML obfuscated from simple scrapers.

**📸 Before/After:**
*(See frontend verification screenshots for visual confirmation of the button and "Copied!" state)*. The button uses the existing Bootstrap `.btn-primary` and Icomoon `.icon-clipboard`.

**♿ Accessibility:**
- Added `aria-label="Copy email address"` to the icon-only button to ensure screen reader users understand its function.
- Added a `title` attribute for mouse hover tooltips.
- The button handles focus and interactive states smoothly.

---
*PR created automatically by Jules for task [2910519472138799430](https://jules.google.com/task/2910519472138799430) started by @sofiadutta*