### PR TITLE
🛡️ Sentinel: Add sandbox attributes to YouTube iframes for defense in depth

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+													<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
💡 **What**
Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` attributes to the two YouTube `<iframe>` embed elements in `index.html`. Also fixed a minor formatting issue in the footer copyright string that caused regression tests to fail.

🎯 **Why**
This provides defense-in-depth by explicitly confining the capabilities of third-party embedded content. If the embedded YouTube player were ever compromised, the restrictive sandbox prevents malicious scripts from accessing top-level navigation, reading parent cookies, or performing unauthorized actions on the host application.

🔧 **Fix**
Used `replace_with_git_merge_diff` to accurately add the attributes specifically to the target iframes without disrupting surrounding HTML structure.

✅ **Verification:**
Ran tracked regression scripts (`python3 verify_changes.py && python3 verify_resize.py`) which completed successfully. Visually verified the attributes in the source code via `git diff`.

---
*PR created automatically by Jules for task [11951885685899256242](https://jules.google.com/task/11951885685899256242) started by @sofiadutta*