### PR TITLE
🎨 Palette: Add copy button for obfuscated email

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" aria-label="Copy email address" title="Copy email address" class="btn btn-primary btn-sm" style="margin-left: 10px; padding: 2px 8px;">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,30 @@
 		}
 	};
 
+	var initCopyEmail = function() {
+		var btn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+		if (btn && emailSpan) {
+			btn.addEventListener('click', function() {
+				var obfuscatedText = emailSpan.textContent || emailSpan.innerText;
+				var realEmail = obfuscatedText.replace(' DOT ', '.').replace(' AT ', '@').replace(' DOT ', '.').replace(/\s+/g, '');
+				navigator.clipboard.writeText(realEmail).then(function() {
+					var icon = btn.querySelector('i');
+					if (icon) {
+						icon.className = 'icon-check';
+					}
+					btn.disabled = true;
+					setTimeout(function() {
+						if (icon) {
+							icon.className = 'icon-clipboard';
+						}
+						btn.disabled = false;
+					}, 2000);
+				});
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +363,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmail();
 	});
 
 


### PR DESCRIPTION
💡 What: Added an inline "copy to clipboard" button next to the obfuscated email address in the Contact section. The button decodes the text (`sofia DOT dutta 17 AT gmail DOT com` -> `sofia.dutta17@gmail.com`) and copies it directly to the clipboard.
🎯 Why: Obfuscating emails provides essential bot protection, but manually re-typing or parsing the obfuscated string is a poor user experience. This fix maintains bot protection (since the real email is only generated via JS on click) while providing a seamless one-click copy experience for users.
📸 Before/After: Screenshot generated and attached.
♿ Accessibility: The copy button is a native `<button>` element with an explicit `aria-label` ("Copy email address") and `title` attribute for screen readers and keyboard users. The decorative Icomoon icon is properly hidden with `aria-hidden="true"`.

---
*PR created automatically by Jules for task [9875755544300927637](https://jules.google.com/task/9875755544300927637) started by @sofiadutta*