### PR TITLE
🎨 Palette: Add Copy button to decode and copy obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-24 - [UX for Obfuscated Text]
+**Learning:** When text (like an email) is obfuscated to prevent bot scraping, it degrades UX by forcing users to manually reformat it.
+**Action:** Implement client-side "Copy" buttons next to obfuscated text that programmatically decode the text before writing it to the clipboard, preserving bot protection while offering seamless UX.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,11 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+									&nbsp;<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email" title="Copy email">
+										<i class="icon-clipboard"></i>
+									</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,7 +339,35 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		initCopyEmail();
 	});
 
+	var initCopyEmail = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				var obfuscated = emailSpan.textContent;
+				// Replace all occurrences of ' DOT ' with '.' by using a global regex
+				var decoded = obfuscated.replace(/ DOT /g, '.').replace(' AT ', '@');
+				// Remove any remaining spaces if the user obfuscated with spaces between the names. The text is "sofia DOT dutta 17 AT gmail DOT com" so we want "sofia.dutta17@gmail.com"
+				decoded = decoded.replace(/\s+/g, '');
+
+				navigator.clipboard.writeText(decoded).then(function() {
+					var originalHTML = copyBtn.innerHTML;
+					copyBtn.innerHTML = 'Copied!';
+					copyBtn.disabled = true;
+					copyBtn.setAttribute('aria-label', 'Email copied');
+
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHTML;
+						copyBtn.disabled = false;
+						copyBtn.setAttribute('aria-label', 'Copy email');
+					}, 2000);
+				});
+			});
+		}
+	};
 
 }());


### PR DESCRIPTION
💡 What: Added an inline "Copy" button next to the obfuscated email address in the contact section that programmatically decodes the text and copies it to the user's clipboard.

🎯 Why: Obfuscated emails (e.g. "sofia DOT dutta 17 AT gmail DOT com") protect against bot scraping, but force legitimate users to manually rewrite the text. This gives users a seamless 1-click experience.

📸 Before/After: The email line now includes a small primary clipboard button that switches to "Copied!" temporarily when clicked.

♿ Accessibility: The button is fully keyboard focusable and utilizes `aria-label` and `title` attributes ("Copy email" -> "Email copied") so screen reader users are notified.

---
*PR created automatically by Jules for task [15257343180051242761](https://jules.google.com/task/15257343180051242761) started by @sofiadutta*