### PR TITLE
🎨 Palette: Add one-click copy button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-24 - [Seamless Copy for Obfuscated Text]
+**Learning:** Users shouldn't have to manually decode bot-protected text (like " DOT " and " AT ") to use an email address. Providing an inline copy button that handles the decoding script-side significantly improves UX while keeping the obfuscation intact for scrapers.
+**Action:** Always pair visually obfuscated text with an accessible, one-click copy mechanism that copies the intended/decoded string, wrapped with temporary visual confirmation.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address" style="margin-left: 10px;">
+											<i class="icon-clipboard3" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,8 +320,33 @@
 		}
 	};
 
+	var setupCopyEmail = function() {
+		var copyBtn = document.getElementById('copy-email-btn');
+		var emailSpan = document.getElementById('obfuscated-email');
+		if (copyBtn && emailSpan) {
+			copyBtn.addEventListener('click', function() {
+				var obfuscatedText = emailSpan.textContent;
+				var decodedEmail = obfuscatedText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+
+				navigator.clipboard.writeText(decodedEmail).then(function() {
+					var originalHTML = copyBtn.innerHTML;
+					copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+					copyBtn.disabled = true;
+
+					setTimeout(function() {
+						copyBtn.innerHTML = originalHTML;
+						copyBtn.disabled = false;
+					}, 2000);
+				}).catch(function(err) {
+					console.error('Failed to copy text: ', err);
+				});
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
+		setupCopyEmail();
 		fullHeight();
 		counter();
 		counterWayPoint();


### PR DESCRIPTION
### 💡 What
Added an inline "Copy" button next to the bot-obfuscated email address in the contact section. The JavaScript decoding logic ensures the real, usable email address is copied to the user's clipboard.

### 🎯 Why
The email address was obfuscated (using " DOT " and " AT ") to prevent bot scraping. This historically required users to manually select the text, copy it, and then manually replace the placeholders before they could use it. This enhancement allows users to seamlessly copy the real, decoded email address with one click, drastically improving the UX while maintaining the text's obfuscation from simple scraping bots.

### 📸 Before/After
**Before:** Users saw `sofia DOT dutta 17 AT gmail DOT com` and had to manually copy and edit the text.
**After:** A primary copy button is available right next to the text. Clicking it temporarily changes the button state to "Copied!" and places the fully decoded `sofia.dutta17@gmail.com` directly onto their clipboard.

### ♿ Accessibility
- Added an `aria-label` and `title` to the new button for screen reader support and tooltip visibility.
- Wrapped the obfuscated text in a `<span>` to guarantee accurate extraction without pulling the button text.
- Button is fully keyboard accessible.
- Provides immediate visual feedback ("Copied!") when the action completes successfully, and explicitly disables the button during this temporary state to prevent overlapping interactions.

---
*PR created automatically by Jules for task [4750537330893683715](https://jules.google.com/task/4750537330893683715) started by @sofiadutta*