### PR TITLE
🎨 Palette: Add accessible copy button for contact email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-23 - [Obfuscated Text and Copy Buttons]
+**Learning:** Obfuscated strings (like "name AT email DOT com") break native copy-paste UX. Wrapping the obfuscated text in a `span`, providing an inline copy button, and decoding the text via JavaScript string replacement before writing it to the clipboard restores usability while maintaining bot protection.
+**Action:** Whenever bot-obfuscated text is used for contact info, always provide an interactive, accessible copy button that decodes the text for the user's clipboard.

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,26 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		var copyEmailBtn = document.getElementById('copy-email-btn');
+		if (copyEmailBtn) {
+			copyEmailBtn.addEventListener('click', function() {
+				var emailSpan = document.getElementById('contact-email');
+				if (emailSpan) {
+					var obfuscatedEmail = emailSpan.textContent;
+					var decodedEmail = obfuscatedEmail.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+					navigator.clipboard.writeText(decodedEmail).then(function() {
+						var originalHtml = copyEmailBtn.innerHTML;
+						copyEmailBtn.innerHTML = 'Copied!';
+						copyEmailBtn.disabled = true;
+						setTimeout(function() {
+							copyEmailBtn.innerHTML = originalHtml;
+							copyEmailBtn.disabled = false;
+						}, 2000);
+					});
+				}
+			});
+		}
 	});
 
 


### PR DESCRIPTION
💡 What: Added an inline "Copy" button next to the obfuscated contact email address that safely decodes and copies the real email to the clipboard, providing temporary visual "Copied!" feedback.

🎯 Why: The original email was obfuscated (e.g., "sofia DOT dutta ...") to protect against bots, but this completely broke the standard copy-paste flow for legitimate users, creating a frustrating manual transcription experience.

📸 Before/After: Screenshots captured in the verification phase showing the new copy icon and the temporary "Copied!" text state when clicked.

♿ Accessibility: Added an `aria-label` and `title` to the icon-only button to ensure screen reader users understand its purpose. The button is fully keyboard-accessible and focusable.

---
*PR created automatically by Jules for task [16712129708523273687](https://jules.google.com/task/16712129708523273687) started by @sofiadutta*