### PR TITLE
🎨 Palette: Add Copy button for obfuscated email

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -861,7 +861,13 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span class="obfuscated-email">sofia DOT dutta 17 AT gmail DOT com</span>
+										&nbsp;
+										<button type="button" class="btn btn-primary btn-sm copy-email-btn" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,30 @@
 		}
 	};
 
+	var handleEmailCopy = function() {
+		var copyBtn = document.querySelector('.copy-email-btn');
+		if (copyBtn) {
+			copyBtn.addEventListener('click', function() {
+				var emailSpan = document.querySelector('.obfuscated-email');
+				if (emailSpan) {
+					var obfuscatedText = emailSpan.textContent;
+					var realEmail = obfuscatedText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+					navigator.clipboard.writeText(realEmail).then(function() {
+						var originalHTML = copyBtn.innerHTML;
+						copyBtn.disabled = true;
+						copyBtn.innerHTML = '<i class="icon-check" aria-hidden="true"></i> Copied!';
+						setTimeout(function() {
+							copyBtn.disabled = false;
+							copyBtn.innerHTML = originalHTML;
+						}, 2000);
+					}).catch(function(err) {
+						console.error('Could not copy text: ', err);
+					});
+				}
+			});
+		}
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +363,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		handleEmailCopy();
 	});
 
 


### PR DESCRIPTION
**💡 What:** Added an interactive "Copy" button next to the obfuscated contact email address. The button uses a JavaScript string replacement to copy the real email to the clipboard while maintaining bot protection.
**🎯 Why:** Manually selecting and deciphering an obfuscated email ("sofia DOT dutta 17 AT gmail DOT com") is a frustrating user experience. This provides a single-click solution.
**📸 Before/After:** Before: Plain obfuscated text. After: Text with a native-styled Bootstrap "Copy" button that updates to "Copied!" and disables itself briefly to provide visual feedback and prevent rapid clicks.
**♿ Accessibility:** The new button includes a descriptive `aria-label` and `title` attribute for screen readers and tooltips, maintaining strong accessibility.

---
*PR created automatically by Jules for task [17437499801995930265](https://jules.google.com/task/17437499801995930265) started by @sofiadutta*