### PR TITLE
🎨 Palette: Add seamless copy button for obfuscated email

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+
+## 2024-05-30 - [Seamless Copy for Obfuscated Text]
+**Learning:** Obfuscating email addresses (e.g., "name DOT last AT domain") effectively prevents bot scraping but creates a frustrating UX for legitimate users who have to manually decode and copy the text.
+**Action:** When using text obfuscation for bot protection, always provide a "Copy" button that uses JavaScript to decode the text on-the-fly before writing it to the clipboard, ensuring both security and a smooth user experience.

--- a/index.html
+++ b/index.html
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<span>sofia DOT dutta 17 AT gmail DOT com</span>
+										<button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard" aria-hidden="true"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -339,6 +339,25 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+
+		var copyEmailBtn = document.getElementById('copy-email-btn');
+		if (copyEmailBtn) {
+			copyEmailBtn.addEventListener('click', function() {
+				var emailText = this.parentNode.querySelector('span').textContent;
+				var decodedEmail = emailText.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+				navigator.clipboard.writeText(decodedEmail).then(function() {
+					var icon = copyEmailBtn.querySelector('i');
+					icon.className = 'icon-check';
+					copyEmailBtn.setAttribute('aria-label', 'Email copied!');
+					copyEmailBtn.setAttribute('title', 'Email copied!');
+					setTimeout(function() {
+						icon.className = 'icon-clipboard';
+						copyEmailBtn.setAttribute('aria-label', 'Copy email address');
+						copyEmailBtn.setAttribute('title', 'Copy email address');
+					}, 2000);
+				});
+			});
+		}
 	});
 
 


### PR DESCRIPTION
## 💡 What
Added a "Copy to clipboard" button next to the obfuscated email address in the contact section. This button uses JavaScript to decode the text on-the-fly and copy the actual email address, updating its icon and tooltip to provide visual confirmation.

## 🎯 Why
Obfuscating email addresses (e.g., "name DOT last AT domain") is effective for bot protection but creates a frustrating UX for legitimate users who must manually decode and type/copy the text. A dedicated copy button provides a seamless, one-click solution that preserves security while vastly improving usability.

## 📸 Before/After
Before: The email was plain text (`sofia DOT dutta 17 AT gmail DOT com`), requiring manual decoding and copying.
After: A clear, styled copy button appears next to the obfuscated email, automatically decoding and copying the real email on click, and providing a success indicator (checkmark icon).

## ♿ Accessibility
The new button includes an `aria-label="Copy email address"` (which updates to "Email copied!" on success) and a corresponding `title` attribute for native tooltips, ensuring screen reader and keyboard users can easily understand and use the interaction.

---
*PR created automatically by Jules for task [16686493784062498816](https://jules.google.com/task/16686493784062498816) started by @sofiadutta*