### PR TITLE
🛡️ Sentinel: Add strict sandbox attributes to third-party iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 			</nav>
 
 			<div class="colorlib-footer">
-				<p><small>&copy; Copyright <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
+				<p><small>Copyright &copy; <span id="copyright-year"></span> All rights reserved. Template by <a href="https://colorlib.com" target="_blank" rel="noopener noreferrer">Colorlib</a>.</small><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer">@Sofia Dutta</a><br>
 					<a href="https://www.linkedin.com/in/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile"><i class="icon-linkedin22" aria-hidden="true"></i></a> |
 					<a href="https://github.com/sofiadutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile"><i class="icon-github" aria-hidden="true"></i></a> |
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
💡 What: Added restrictive `sandbox` attributes to YouTube iframe embeds.
🎯 Why: Enforces strict containment of third-party content and prevents potential cross-site scripting (XSS) breakouts by restricting the actions the iframe can perform.
🔧 Fix: Added `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"` to all third-party YouTube iframes.
✅ Verification: Verified the `sandbox` attribute is correctly applied in the HTML source and passes existing regression tests.

---
*PR created automatically by Jules for task [12411411572910586370](https://jules.google.com/task/12411411572910586370) started by @sofiadutta*