### PR TITLE
🎨 Palette: Add copy button for obfuscated email

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p><span id="contact-email">sofia DOT dutta 17 AT gmail DOT com</span> <button id="copy-email-btn" class="btn btn-primary btn-sm" aria-label="Copy email address" title="Copy email address"><i class="icon-clipboard"></i></button></p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,25 @@
 		}
 	};
 
+	var handleEmailCopy = function() {
+		$('#copy-email-btn').on('click', function() {
+			var obfuscatedEmail = $('#contact-email').text();
+			var email = obfuscatedEmail.replace(/ DOT /g, '.').replace(/ AT /g, '@').replace(/ /g, '');
+			var $btn = $(this);
+			var $icon = $btn.find('i');
+
+			navigator.clipboard.writeText(email).then(function() {
+				$icon.removeClass('icon-clipboard').addClass('icon-check');
+				$btn.attr('aria-label', 'Email address copied').attr('title', 'Email address copied');
+
+				setTimeout(function() {
+					$icon.removeClass('icon-check').addClass('icon-clipboard');
+					$btn.attr('aria-label', 'Copy email address').attr('title', 'Copy email address');
+				}, 2000);
+			});
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +358,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		handleEmailCopy();
 	});
 
 


### PR DESCRIPTION
💡 What: Added a copy-to-clipboard button next to the obfuscated email address in the Contact section.
🎯 Why: The email address is obfuscated ("sofia DOT dutta 17 AT gmail DOT com") to prevent bot scraping, which is great for security but creates friction for users trying to contact the owner. This button decodes the email before copying, providing a seamless UX.
📸 Before/After: Visual changes can be seen in the attached screenshots (a small clipboard icon button appears next to the email, turning into a checkmark upon click).
♿ Accessibility: The button is fully keyboard accessible, uses an existing Bootstrap class structure, and includes appropriate `aria-label` and `title` attributes that update dynamically upon copying to inform screen readers of the success state.

---
*PR created automatically by Jules for task [11767834242971362046](https://jules.google.com/task/11767834242971362046) started by @sofiadutta*