### PR TITLE
⚡ Bolt: Use passive native scroll listener for offcanvas menu

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -149,14 +149,17 @@
 	    }
 		});
 
-		$(window).scroll(function(){
-			if ( $('body').hasClass('offcanvas') ) {
+		// Optimization: Native passive scroll listener prevents blocking the main thread
+		window.addEventListener('scroll', function() {
+			if ( document.body.classList.contains('offcanvas') ) {
 
-    			$('body').removeClass('offcanvas');
-    			$('.js-colorlib-nav-toggle').removeClass('active');
+			document.body.classList.remove('offcanvas');
+			document.querySelectorAll('.js-colorlib-nav-toggle').forEach(function(el) {
+					el.classList.remove('active');
+				});
 			
 	    	}
-		});
+		}, { passive: true });
 
 	};
 


### PR DESCRIPTION
💡 What: Replaced jQuery scroll event listener for removing `.offcanvas` class with a native JavaScript passive event listener.
🎯 Why: jQuery scroll listeners run on the main thread and block rendering while waiting for a potential `preventDefault()`. Using a native passive listener ensures smooth scrolling performance, as the browser knows it will not be blocked.
📊 Impact: Reduces main-thread blocking during scrolling.
🔬 Measurement: Verified functionality locally via automated UI tests triggering scrolling events on mobile viewports.

---
*PR created automatically by Jules for task [13177814917932688146](https://jules.google.com/task/13177814917932688146) started by @sofiadutta*