### PR TITLE
🎨 Palette: Better UX for obfuscated emails

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-23 - [Email Obfuscation UX]
+**Learning:** Obfuscating emails by replacing `@` with `AT` and `.` with `DOT` helps prevent spam, but degrades UX by breaking `mailto:` links and forcing users to manually correct the text when copying.
+**Action:** Use data attributes (e.g., `data-user`, `data-domain`) to store email parts, and reconstruct them client-side to create functional `mailto:` links and easy copy-to-clipboard buttons, maintaining spam protection while vastly improving user experience.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" data-user="sofia.dutta17" data-domain="gmail.com" class="btn-hire js-email-protect">Hire me</a>
 									</div>
 								</div>
 							</div>
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										<a href="#" data-user="sofia.dutta17" data-domain="gmail.com" class="js-email-protect" style="color: inherit; text-decoration: none;">sofia DOT dutta 17 AT gmail DOT com</a>
+										<button class="btn btn-primary btn-sm js-email-copy" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address" title="Copy to clipboard" style="margin-left: 10px; padding: 4px 10px;">
+											<i class="icon-clipboard"></i> Copy
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -314,6 +314,48 @@
 		}
 	};
 
+	var emailProtect = function() {
+		$('.js-email-protect').each(function() {
+			var $el = $(this);
+			var user = $el.data('user');
+			var domain = $el.data('domain');
+			if (user && domain) {
+				var email = user + '@' + domain;
+				if ($el.text().indexOf('DOT') > -1 || $el.text().indexOf('AT') > -1) {
+					$el.text(email);
+				}
+			}
+		});
+
+		$('.js-email-protect').on('click', function(e) {
+			e.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			if (user && domain) {
+				window.location.href = 'mailto:' + user + '@' + domain;
+			}
+		});
+
+		$('.js-email-copy').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var user = $btn.data('user');
+			var domain = $btn.data('domain');
+			if (user && domain) {
+				var email = user + '@' + domain;
+
+				navigator.clipboard.writeText(email).then(function() {
+					var $icon = $btn.find('i');
+					var originalClass = $icon.attr('class');
+					$icon.attr('class', 'icon-check');
+					setTimeout(function() {
+						$icon.attr('class', originalClass);
+					}, 2000);
+				});
+			}
+		});
+	};
+
 	var updateCopyrightYear = function() {
 		if ($('#copyright-year').length > 0) {
 			$('#copyright-year').text(new Date().getFullYear());
@@ -339,6 +381,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailProtect();
 	});
 
 


### PR DESCRIPTION
💡 What: Replaced static obfuscated emails with dynamic text reconstruction and added a dedicated 'Copy' button in the contact section.
🎯 Why: Users frequently need to copy email addresses. Obfuscating them with 'AT' and 'DOT' breaks the native mailto link and forces manual correction. This change improves both clickability and copyability while maintaining basic spam protection.
📸 Before/After: Before, it was just plain text 'sofia DOT dutta 17 AT gmail DOT com'. Now, it reconstructs into a proper email, and has a handy copy button with feedback.
♿ Accessibility: Added `aria-label` to the copy button for screen readers.

---
*PR created automatically by Jules for task [10840280680081293828](https://jules.google.com/task/10840280680081293828) started by @sofiadutta*