### PR TITLE
🛡️ Sentinel: Add security sandbox attributes to YouTube iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+## 2026-06-16 - Sandbox Missing from YouTube iframes
+**Vulnerability:** YouTube `iframe` embeds in `index.html` were missing the `sandbox` attribute, potentially allowing third-party content to execute malicious actions like top-level page navigation or unauthorized form submissions.
+**Learning:** Even well-known third-party embeds should be sandboxed to adhere to the principle of least privilege.
+**Prevention:** Always include the `sandbox` attribute (`allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox`) when embedding external content via `iframe`.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox" title="Smart home controller app with rules demo">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox" title="Smart home controller app demo">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🛡️ Sentinel: Add security sandbox attributes to YouTube iframes

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** YouTube `iframe` embeds were missing the `sandbox` attribute, potentially allowing third-party content to execute malicious actions (like top-level navigation).
🎯 **Impact:** Prevents the embedded content from performing unauthorized actions outside of playing the video and expected interactive features.
🔧 **Fix:** Added the `sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox"` attribute to both YouTube iframes in `index.html`.
✅ **Verification:** Visually verified that the layout remains the same and videos load correctly without errors using Playwright. Existing regression tests pass.

---
*PR created automatically by Jules for task [9513093018773898258](https://jules.google.com/task/9513093018773898258) started by @sofiadutta*