### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing sandbox attributes on iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Inline `document.write` script in `index.html` was blocked by the existing Content Security Policy (CSP) which correctly restricts `script-src` to `self` and specific domains, without allowing `unsafe-inline`.
 **Learning:** Even "harmless" inline scripts like printing the current year are security violations under strict CSPs. The existing code was actually broken (script blocked) because of the security policy.
 **Prevention:** Avoid inline JavaScript entirely. Move all logic to external `.js` files or use DOM manipulation from existing scripts.
+## 2024-06-17 - Third-Party Iframe Security Enhancement
+**Vulnerability:** Embedded YouTube iframes lacked the \`sandbox\` attribute, potentially allowing third-party scripts to have broader permissions than necessary.
+**Learning:** Adding standard \`sandbox\` attributes to iframes (with \`allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox\`) is a simple defense-in-depth measure that should be standard practice.
+**Prevention:** Always include the \`sandbox\` attribute when embedding third-party content like video players.

--- a/index.html
+++ b/index.html
@@ -809,7 +809,7 @@
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
 												<h2>Smart home controller app with rules demo</h2>
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/DZq-oZ_Cv1g" loading="lazy" allowfullscreen title="Smart home controller app with rules demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox">
 													Smart home controller app with rules demo
 												</iframe>
 											</div>
@@ -826,7 +826,7 @@
 
 										<div class="timeline-label">
 											<div class="embed-responsive embed-responsive-16by9">
-												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo">
+												<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/rOWJNGHVcHo" loading="lazy" allowfullscreen title="Smart home controller app demo" sandbox="allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox">
 													Smart home controller app demo
 												</iframe>
 											</div>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Embedded YouTube iframes lacked the `sandbox` attribute. This is a security risk as it could potentially allow third-party scripts loaded within the iframe to have broader permissions than necessary, such as navigating the top-level parent window.
🎯 Impact: While YouTube is generally trusted, defense-in-depth requires restricting the capabilities of any third-party embedded content to only what is necessary, preventing potential XSS or unexpected behavior if the source is compromised or serves unexpected content.
🔧 Fix: Added the `sandbox` attribute to both YouTube iframes in `index.html` with the specific permissions required for the player to function correctly: `allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox`.
✅ Verification: Ran regression tests and verified via visual inspection (Playwright screenshot) that the iframes still render correctly.

---
*PR created automatically by Jules for task [1595394365445165293](https://jules.google.com/task/1595394365445165293) started by @sofiadutta*