### PR TITLE
🎨 Palette: Obfuscate email and add copy to clipboard button for Hire Me link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-23 - [Email Link Obfuscation and Copy Action]
+**Learning:** Raw `mailto:` links can be frustrating for users without a default email client and invite spam. Adding a one-click "copy to clipboard" button with visual feedback next to the obfuscated email action significantly improves the hiring workflow for recruiters and users.
+**Action:** Always wrap email links with `data-user` and `data-domain` attributes, reconstruct them on the client-side, and provide a dedicated copy button with temporary visual confirmation (like a checkmark).

--- a/css/style.css
+++ b/css/style.css
@@ -447,7 +447,14 @@ body.offcanvas {
     text-transform: uppercase;
     letter-spacing: 1px;
     bordeR: 1px solid #000;
-    padding: 2px 10px; }
+    padding: 2px 10px;
+    margin-right: 5px;
+    background: transparent;
+    cursor: pointer;
+    display: inline-block; }
+    .hire .btn-hire:hover {
+        background: #000;
+        color: #f9bf3f; }
 
 .fancy-collapse-panel .panel-default > .panel-heading {
   padding: 0; }

--- a/index.html
+++ b/index.html
@@ -160,7 +160,10 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" data-user="sofia.dutta17" data-domain="gmail.com" class="btn-hire js-email-protect">Hire me</a>
+										<button data-user="sofia.dutta17" data-domain="gmail.com" class="btn-hire js-copy-email" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard"></i>
+										</button>
 									</div>
 								</div>
 							</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,6 +320,34 @@
 		}
 	};
 
+	var emailProtect = function() {
+		$('.js-email-protect').on('click', function(e) {
+			e.preventDefault();
+			var user = $(this).attr('data-user');
+			var domain = $(this).attr('data-domain');
+			window.location.href = 'mailto:' + encodeURIComponent(user) + '@' + encodeURIComponent(domain);
+		});
+
+		$('.js-copy-email').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var user = $btn.attr('data-user');
+			var domain = $btn.attr('data-domain');
+			var email = user + '@' + domain;
+
+			if (navigator.clipboard) {
+				navigator.clipboard.writeText(email).then(function() {
+					$btn.html('<i class="icon-check"></i>');
+					setTimeout(function() {
+						$btn.html('<i class="icon-clipboard"></i>');
+					}, 2000);
+				}).catch(function(err) {
+					console.error('Failed to copy text: ', err);
+				});
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
 		fullHeight();
@@ -339,6 +367,7 @@
 		stickyFunction();
 		lazyLoadBackgrounds();
 		updateCopyrightYear();
+		emailProtect();
 	});
 
 


### PR DESCRIPTION
💡 What: Replaced the raw `mailto:` link for the "Hire me" button with client-side JavaScript obfuscation using `data-user` and `data-domain` attributes, and added a dedicated one-click "copy to clipboard" button with visual feedback (a temporary checkmark).

🎯 Why: Raw `mailto:` links can be frustrating for users who do not have a default email client set up on their device (e.g., launching an unexpected Mail app). They also make the email address easily scrapable by bots. Adding a copy button empowers recruiters to easily copy the email for their ATS or preferred webmail client.

📸 Before/After: Verified visually via Playwright headless testing. The "Hire me" button remains functionally styled but now features an adjacent "clipboard" icon button. Upon clicking the clipboard icon, the icon transforms into a "check" mark for 2 seconds to confirm the copy action before reverting.

♿ Accessibility: Added `aria-label="Copy email address"` and `title="Copy email address"` to the new icon-only copy button to ensure it is fully accessible to screen reader users and provides a native tooltip for mouse users. Keyboard focus states remain intact via the `.btn-hire` class styling.

---
*PR created automatically by Jules for task [7764225697963122246](https://jules.google.com/task/7764225697963122246) started by @sofiadutta*