### PR TITLE
🎨 Palette: Improve email obfuscation UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-05-23 - [Tooltips for Icon-Only Buttons]
 **Learning:** Icon-only buttons (like social links) are ambiguous for mouse users. While `aria-label` helps screen readers, sighted users benefit significantly from a native browser tooltip via the `title` attribute.
 **Action:** Always add `title` attributes matching the `aria-label` for icon-only interactive elements.
+## 2024-05-23 - [Interactive Email Obfuscation]
+**Learning:** Hardcoding obfuscated emails (e.g. "user AT domain DOT com") is inconvenient for users who want to contact the person quickly, but leaving emails as cleartext exposes them to spam bots.
+**Action:** Always implement a middle ground using data attributes combined with a JS click handler for `mailto:` and an interactive "Copy to Clipboard" button providing quick cleartext access to the user while keeping the DOM clear of raw emails.

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 								<div class="col-md-12 animate-box" data-animate-effect="fadeInRight">
 									<div class="hire">
 										<h3>Master's in Data Science with a <strong>4.0</strong> GPA!</h3>
-										<a href="mailto:sofia.dutta17@gmail.com" target="_blank" rel="noopener noreferrer" class="btn-hire">Hire me</a>
+										<a href="#" data-user="sofia.dutta17" data-domain="gmail.com" class="btn-hire js-email-protect">Hire me</a>
 									</div>
 								</div>
 							</div>
@@ -861,7 +861,12 @@
 									<i class="icon-mail6"></i>
 								</div>
 								<div class="colorlib-text">
-									<p>sofia DOT dutta 17 AT gmail DOT com</p>
+									<p>
+										sofia DOT dutta 17 AT gmail DOT com
+										<button class="btn btn-primary btn-xs js-copy-email" data-user="sofia.dutta17" data-domain="gmail.com" aria-label="Copy email address" title="Copy email address">
+											<i class="icon-clipboard"></i>
+										</button>
+									</p>
 								</div>
 							</div>
 						</div>

--- a/js/main.js
+++ b/js/main.js
@@ -320,8 +320,45 @@
 		}
 	};
 
+	var emailProtection = function() {
+		$('.js-email-protect').on('click', function(e) {
+			e.preventDefault();
+			var user = $(this).data('user');
+			var domain = $(this).data('domain');
+			if (user && domain) {
+				window.location.href = 'mailto:' + encodeURIComponent(user) + '@' + encodeURIComponent(domain);
+			}
+		});
+
+		$('.js-copy-email').on('click', function(e) {
+			e.preventDefault();
+			var $btn = $(this);
+			var user = $btn.data('user');
+			var domain = $btn.data('domain');
+
+			if (user && domain) {
+				var email = user + '@' + domain;
+
+				navigator.clipboard.writeText(email).then(function() {
+					$btn.html('<i class="icon-check"></i>');
+					$btn.attr('aria-label', 'Copied!');
+					$btn.attr('title', 'Copied!');
+
+					setTimeout(function() {
+						$btn.html('<i class="icon-clipboard"></i>');
+						$btn.attr('aria-label', 'Copy email address');
+						$btn.attr('title', 'Copy email address');
+					}, 2000);
+				}).catch(function(err) {
+					console.error('Failed to copy email: ', err);
+				});
+			}
+		});
+	};
+
 	// Document on load.
 	$(function(){
+		emailProtection();
 		fullHeight();
 		counter();
 		counterWayPoint();


### PR DESCRIPTION
💡 **What**: Added an interactive "Copy to Clipboard" button next to the obfuscated email address and converted the "Hire me" button's cleartext `mailto:` link into a JS-handled action using data attributes.
🎯 **Why**: Obfuscated text emails (e.g., `user AT domain DOT com`) are frustrating for users to manually decipher and type out. Cleartext `mailto:` links are targets for spam bots. This implementation strikes a middle ground: it protects the email from simple DOM scrapers while providing users an instant, accessible way to copy the cleartext email or trigger their email client.
📸 **Before/After**: Visually, a small copy button now appears next to the email text.
♿ **Accessibility**: The copy button includes an `aria-label` ("Copy email address") and `title` tooltip for screen readers and sighted users. The tooltip updates to "Copied!" and the icon changes to a checkmark to provide immediate visual feedback upon interaction.

---
*PR created automatically by Jules for task [6723158049475370682](https://jules.google.com/task/6723158049475370682) started by @sofiadutta*